### PR TITLE
Things added when running 2017 JES

### DIFF
--- a/mkShapesRDF/processor/data/LeptonSel_cfg.py
+++ b/mkShapesRDF/processor/data/LeptonSel_cfg.py
@@ -8,6 +8,140 @@ LepFilter_dict = {
 }
 
 ElectronWP = {
+    "Full2017v9": {
+        "VetoObjWP": {
+            "HLTsafe": {
+                "cuts": {
+                    # Common cuts
+                    "True": ["False"],
+                },
+            },
+        },
+  
+        # ------------
+        "FakeObjWP": {
+            "HLTsafe": {
+                "cuts": {
+                    # Common cuts
+                    "ROOT::RVecB (Electron_pt.size(), true)": [
+                        "ROOT::VecOps::abs(Electron_eta) < 2.5",
+                        "Electron_cutBased >= 3",
+                        "Electron_convVeto == 1",
+                    ],
+                    # Barrel
+                    "ROOT::VecOps::abs(Electron_eta)  <= 1.479": [
+                        "ROOT::VecOps::abs(Electron_dxy) < 0.05",
+                        "ROOT::VecOps::abs(Electron_dz)  < 0.1",
+                    ],
+                    # EndCap
+                    "ROOT::VecOps::abs(Electron_eta)  > 1.479": [
+                        "Electron_sieie  < 0.03",
+                        "ROOT::VecOps::abs(Electron_eInvMinusPInv) < 0.014",
+                        "ROOT::VecOps::abs(Electron_dxy) < 0.1",
+                        "ROOT::VecOps::abs(Electron_dz)  < 0.2",
+                    ],
+                },
+            },
+        },
+
+ 
+        "TightObjWP": {
+            # TODO this section is missing SF files
+            # ----- mvaFall17V2Iso
+            "mvaFall17V2Iso_WP90": {
+                "cuts": {
+                    # Common cuts
+                    "ROOT::RVecB (Electron_pt.size(), true)": [
+                        "ROOT::VecOps::abs(Electron_eta) < 2.5",
+                        "Electron_mvaFall17V2Iso_WP90",
+                        "Electron_convVeto == 1",
+                        "Electron_pfRelIso03_all < 0.06",
+                    ],
+                    # Barrel
+                    "ROOT::VecOps::abs(Electron_eta) <= 1.479": [
+                        "ROOT::VecOps::abs(Electron_dxy) < 0.05",
+                        "ROOT::VecOps::abs(Electron_dz)  < 0.1",
+                    ],
+                    # EndCap
+                    "ROOT::VecOps::abs(Electron_eta) > 1.479": [
+                        "ROOT::VecOps::abs(Electron_dxy) < 0.1",
+                        "ROOT::VecOps::abs(Electron_dz) <  0.2",
+                    ],
+                }
+            },
+            # ----- mvaFall17V2Iso + ttHMVA
+            "mvaFall17V2Iso_WP90_tthmva_70": {
+                "cuts": {
+                    # Common cuts
+                    "ROOT::RVecB (Electron_pt.size(), true)": [
+                        "ROOT::VecOps::abs(Electron_eta) < 2.5",
+                        "Electron_mvaFall17V2Iso_WP90",
+                        "Electron_convVeto == 1",
+                        "Electron_pfRelIso03_all < 0.06",
+                        "Electron_mvaTTH > 0.7",
+                    ],
+                    # Barrel
+                    "ROOT::VecOps::abs(Electron_eta) <= 1.479": [
+                        "ROOT::VecOps::abs(Electron_dxy) < 0.05",
+                        "ROOT::VecOps::abs(Electron_dz)  < 0.1",
+                    ],
+                    # EndCap
+                    "ROOT::VecOps::abs(Electron_eta) > 1.479": [
+                        "ROOT::VecOps::abs(Electron_dxy) < 0.1",
+                        "ROOT::VecOps::abs(Electron_dz) <  0.2",
+                    ],
+                }
+            },
+            # ----- mvaFall17V2Iso + SS
+            "mvaFall17V2Iso_WP90_SS": {
+                "cuts": {
+                    # Common cuts
+                    "ROOT::RVecB (Electron_pt.size(), true)": [
+                        "ROOT::VecOps::abs(Electron_eta) < 2.5",
+                        "Electron_mvaFall17V2Iso_WP90",
+                        "Electron_convVeto == 1",
+                        "Electron_pfRelIso03_all < 0.06",
+                        "Electron_tightCharge == 2",
+                    ],
+                    # Barrel
+                    "ROOT::VecOps::abs(Electron_eta) <= 1.479": [
+                        "ROOT::VecOps::abs(Electron_dxy) < 0.05",
+                        "ROOT::VecOps::abs(Electron_dz)  < 0.1",
+                    ],
+                    # EndCap
+                    "ROOT::VecOps::abs(Electron_eta) > 1.479": [
+                        "ROOT::VecOps::abs(Electron_dxy) < 0.1",
+                        "ROOT::VecOps::abs(Electron_dz) <  0.2",
+                    ],
+                }
+            },
+            # ----- mvaFall17V2Iso + SS + ttHMVA
+            "mvaFall17V2Iso_WP90_SS_tthmva_70": {
+                "cuts": {
+                    # Common cuts
+                    "ROOT::RVecB (Electron_pt.size(), true)": [
+                        "ROOT::VecOps::abs(Electron_eta) < 2.5",
+                        "Electron_mvaFall17V2Iso_WP90",
+                        "Electron_convVeto == 1",
+                        "Electron_pfRelIso03_all < 0.06",
+                        "Electron_tightCharge == 2",
+                        "Electron_mvaTTH > 0.7",
+                    ],
+                    # Barrel
+                    "ROOT::VecOps::abs(Electron_eta) <= 1.479": [
+                        "ROOT::VecOps::abs(Electron_dxy) < 0.05",
+                        "ROOT::VecOps::abs(Electron_dz)  < 0.1",
+                    ],
+                    # EndCap
+                    "ROOT::VecOps::abs(Electron_eta) > 1.479": [
+                        "ROOT::VecOps::abs(Electron_dxy) < 0.1",
+                        "ROOT::VecOps::abs(Electron_dz) <  0.2",
+                    ],
+                }
+            }
+        },
+    },
+
     "Full2018v9": {
         "VetoObjWP": {
             "HLTsafe": {
@@ -70,6 +204,87 @@ ElectronWP = {
 }
 
 MuonWP = {
+    # ____________________Full2017v9__________________________
+    "Full2017v9": {
+        # ------------
+        "VetoObjWP": {
+            "HLTsafe": {
+                "cuts": {
+                    # Common cuts
+                    "ROOT::RVecB (Muon_pt.size(), true)": [
+                        "ROOT::VecOps::abs(Muon_eta) < 2.4",
+                        "Muon_pt > 10.0",
+                    ]
+                },
+            }
+        },
+        # ------------
+        "FakeObjWP": {
+            "HLTsafe": {
+                "cuts": {
+                    # Common cuts
+                    "ROOT::RVecB (Muon_pt.size(), true)": [
+                        "ROOT::VecOps::abs(Muon_eta) < 2.4",
+                        "Muon_tightId == 1",
+                        "ROOT::VecOps::abs(Muon_dz) < 0.1",
+                        "Muon_pfRelIso04_all < 0.4",
+                    ],
+                    # dxy for pT < 20 GeV
+                    "Muon_pt <= 20.0": [
+                        "ROOT::VecOps::abs(Muon_dxy) < 0.01",
+                    ],
+                    # dxy for pT > 20 GeV
+                    "Muon_pt > 20.0": [
+                        "ROOT::VecOps::abs(Muon_dxy) < 0.02",
+                    ],
+                },
+            },
+        },
+        # ------------
+        # TODO this section is missing SF files
+        "TightObjWP": {
+            "cut_Tight_HWWW": {
+                "cuts": {
+                    # Common cuts
+                    "ROOT::RVecB (Muon_pt.size(), true)": [
+                        "ROOT::VecOps::abs(Muon_eta) < 2.4",
+                        "Muon_tightId == 1",
+                        "ROOT::VecOps::abs(Muon_dz) < 0.1",
+                        "Muon_pfRelIso04_all < 0.15",
+                    ],
+                    # dxy for pT < 20 GeV
+                    "Muon_pt <= 20.0": [
+                        "ROOT::VecOps::abs(Muon_dxy) < 0.01",
+                    ],
+                    # dxy for pT > 20 GeV
+                    "Muon_pt > 20.0": [
+                        "ROOT::VecOps::abs(Muon_dxy) < 0.02",
+                    ],
+                },
+            },
+            "cut_Tight_HWWW_tthmva_80": {
+                "cuts": {
+                    # Common cuts
+                    "ROOT::RVecB (Muon_pt.size(), true)": [
+                        "ROOT::VecOps::abs(Muon_eta) < 2.4",
+                        "Muon_tightId == 1",
+                        "ROOT::VecOps::abs(Muon_dz) < 0.1",
+                        "Muon_pfRelIso04_all < 0.15",
+                        "Muon_mvaTTH > 0.8",
+                    ],
+                    # dxy for pT < 20 GeV
+                    "Muon_pt <= 20.0": [
+                        "ROOT::VecOps::abs(Muon_dxy) < 0.01",
+                    ],
+                    # dxy for pT > 20 GeV
+                    "Muon_pt > 20.0": [
+                        "ROOT::VecOps::abs(Muon_dxy) < 0.02",
+                    ],
+                },
+            }
+        }
+    },
+
     # ____________________Full2018v9__________________________
     "Full2018v9": {
         # ------------

--- a/mkShapesRDF/processor/data/formulasToAdd_MC_Full2017v9.py
+++ b/mkShapesRDF/processor/data/formulasToAdd_MC_Full2017v9.py
@@ -1,0 +1,283 @@
+# Formulas to be added, in python language.
+# Call to branches have to be in the form branchName (i.e. no "event.").
+# If you want to use logical operators, the have to be the c++ ones (i.e "&&" not " and ")
+
+from mkShapesRDF.processor.data.LeptonSel_cfg import ElectronWP
+from mkShapesRDF.processor.data.LeptonSel_cfg import MuonWP
+
+formulas = {}
+
+# from https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2#2018_2017_data_and_MC_UL
+
+METFilter_Common = """(
+                    Flag_goodVertices*
+                    Flag_globalSuperTightHalo2016Filter*
+                    Flag_HBHENoiseFilter*
+                    Flag_HBHENoiseIsoFilter*
+                    Flag_EcalDeadCellTriggerPrimitiveFilter*
+                    Flag_BadPFMuonFilter*
+                    Flag_BadPFMuonDzFilter*
+                    Flag_ecalBadCalibFilter
+                    )"""
+
+METFilter_DATA = METFilter_Common + "*" + "(Flag_eeBadScFilter)"
+
+formulas["METFilter_MC"] = METFilter_DATA
+
+# Common Weights
+
+
+if "genWeight" in df.GetColumnNames():
+    formulas["XSWeight"] = "baseW*genWeight"
+else:
+    formulas["XSWeight"] = "baseW"
+
+
+formulas["SFweight2l"] = """(nLepton > 1) ? (puWeight*
+                              (HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL ||
+                               HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ ||
+                               HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ ||
+                               HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ ||
+                               HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8 ||
+                               HLT_IsoMu27 ||
+                               HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL ||
+                               HLT_Ele35_WPTight_Gsf )*
+                             TriggerSFWeight_2l*
+                             Lepton_RecoSF[0]*
+                             Lepton_RecoSF[1]*
+                             EMTFbug_veto) : 0.0
+                          """
+
+formulas["SFweight3l"] = """(nLepton > 2) ? (puWeight*
+                              (HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL ||
+                               HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ ||
+                               HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ ||
+                               HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ ||
+                               HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8 ||
+                               HLT_IsoMu27 ||
+                               HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL ||
+                               HLT_Ele35_WPTight_Gsf)*
+                             TriggerSFWeight_3l*
+                             Lepton_RecoSF[0]*
+                             Lepton_RecoSF[1]*
+                             Lepton_RecoSF[2]*
+                             EMTFbug_veto) : 0.0
+                         """
+
+formulas["SFweight4l"] = """(nLepton > 3) ? (puWeight*
+                              (HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL ||
+                               HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ ||
+                               HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ ||
+                               HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ ||
+                               HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8 ||
+                               HLT_IsoMu27 ||
+                               HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL ||
+                               HLT_Ele35_WPTight_Gsf)*
+                             TriggerSFWeight_4l*
+                             Lepton_RecoSF[0]*
+                             Lepton_RecoSF[1]*
+                             Lepton_RecoSF[2]*
+                             Lepton_RecoSF[3]*
+                             EMTFbug_veto) : 0.0
+                         """
+
+## MonoHiggs
+if "MHTriggerEffWeight_2l" in df.GetColumnNames():
+    # # MonoHiggs
+    formulas["SFweight2lMH"] = """(nLepton > 1) ? 
+                                  (puWeight*
+                                   MHTriggerEffWeight_2l*
+                                   Lepton_RecoSF[0]*
+                                   Lepton_RecoSF[1]*
+                                   EMTFbug_veto) : 0.0
+                               """
+else:
+    formulas["SFweight2lMH"] = "0.0"
+
+# Lepton WP
+muWPlist = [wp for wp in MuonWP["Full2017v9"]["TightObjWP"]]
+eleWPlist = [wp for wp in ElectronWP["Full2017v9"]["TightObjWP"]]
+
+for eleWP in eleWPlist:
+  for muWP in muWPlist:
+
+    formulas[f"LepSF2l__ele_{eleWP}__mu_{muWP}"] = f"""(nLepton > 1) ? 
+                                                       Lepton_tightElectron_{eleWP}_IdIsoSF[0]*
+                                                       Lepton_tightElectron_{eleWP}_IdIsoSF[1]*
+                                                       Lepton_tightMuon_{muWP}_IdIsoSF[0]*
+                                                       Lepton_tightMuon_{muWP}_IdIsoSF[1] 
+                                                       : 0.0 
+                                                    """
+  
+    formulas[f"LepSF3l__ele_{eleWP}__mu_{muWP}"] = f"""(nLepton > 2) ?
+                                                       Lepton_tightElectron_{eleWP}_IdIsoSF[0]*
+                                                       Lepton_tightElectron_{eleWP}_IdIsoSF[1]*
+                                                       Lepton_tightElectron_{eleWP}_IdIsoSF[2]*
+                                                       Lepton_tightMuon_{muWP}_IdIsoSF[0]*
+                                                       Lepton_tightMuon_{muWP}_IdIsoSF[1]*
+                                                       Lepton_tightMuon_{muWP}_IdIsoSF[2]
+                                                       : 0.0
+                                                    """
+  
+    formulas[f"LepSF4l__ele_{eleWP}__mu_{muWP}"] = f"""(nLepton > 3) ?
+                                                       Lepton_tightElectron_{eleWP}_IdIsoSF[0]*
+                                                       Lepton_tightElectron_{eleWP}_IdIsoSF[1]*
+                                                       Lepton_tightElectron_{eleWP}_IdIsoSF[2]*
+                                                       Lepton_tightElectron_{eleWP}_IdIsoSF[3]*
+                                                       Lepton_tightMuon_{muWP}_IdIsoSF[0]*
+                                                       Lepton_tightMuon_{muWP}_IdIsoSF[1]*
+                                                       Lepton_tightMuon_{muWP}_IdIsoSF[2]*
+                                                       Lepton_tightMuon_{muWP}_IdIsoSF[3]
+                                                       : 0.0
+                                                    """
+  
+    formulas[f"LepCut2l__ele_{eleWP}__mu_{muWP}"] = f"""(nLepton > 1) ? 
+                                                        ((Lepton_isTightElectron_{eleWP}[0]>0.5 || Lepton_isTightMuon_{muWP}[0]>0.5) &&
+                                                         (Lepton_isTightElectron_{eleWP}[1]>0.5 || Lepton_isTightMuon_{muWP}[1]>0.5))
+                                                        : 0.0
+                                                     """
+
+  
+    formulas[f"LepCut3l__ele_{eleWP}__mu_{muWP}"] = f"""(nLepton > 2) ? 
+                                                        ((Lepton_isTightElectron_{eleWP}[0]>0.5 || Lepton_isTightMuon_{muWP}[0]>0.5) &&
+                                                         (Lepton_isTightElectron_{eleWP}[1]>0.5 || Lepton_isTightMuon_{muWP}[1]>0.5) &&
+                                                         (Lepton_isTightElectron_{eleWP}[2]>0.5 || Lepton_isTightMuon_{muWP}[2]>0.5))
+                                                        : 0.0
+                                                    """
+  
+    formulas[f"LepCut4l__ele_{eleWP}__mu_{muWP}"] = f"""(nLepton > 3) ?
+                                                        ((Lepton_isTightElectron_{eleWP}[0]>0.5 || Lepton_isTightMuon_{muWP}[0]>0.5) &&
+                                                         (Lepton_isTightElectron_{eleWP}[1]>0.5 || Lepton_isTightMuon_{muWP}[1]>0.5) &&
+                                                         (Lepton_isTightElectron_{eleWP}[2]>0.5 || Lepton_isTightMuon_{muWP}[2]>0.5) &&
+                                                         (Lepton_isTightElectron_{eleWP}[3]>0.5 || Lepton_isTightMuon_{muWP}[3]>0.5))
+                                                        : 0.0
+                                                     """
+
+for eleWP in eleWPlist:
+
+  formulas[f"LepSF2l__ele_{eleWP}__Up"] = f"""(nLepton > 1) ?
+                                              ((abs(Lepton_pdgId[0]) == 11)*(Lepton_tightElectron_{eleWP}_TotSF_Up[0])/(Lepton_tightElectron_{eleWP}_TotSF[0])+
+                                               (abs(Lepton_pdgId[0]) == 13)) * 
+                                              ((abs(Lepton_pdgId[1]) == 11)*(Lepton_tightElectron_{eleWP}_TotSF_Up[1])/(Lepton_tightElectron_{eleWP}_TotSF[1])+
+                                               (abs(Lepton_pdgId[1]) == 13)) 
+                                              : 0.0
+                                           """
+
+  formulas[f"LepSF2l__ele_{eleWP}__Do"] = f"""(nLepton > 1) ?
+                                              ((abs(Lepton_pdgId[0]) == 11)*(Lepton_tightElectron_{eleWP}_TotSF_Down[0])/(Lepton_tightElectron_{eleWP}_TotSF[0])+
+                                               (abs(Lepton_pdgId[0]) == 13)) * 
+                                              ((abs(Lepton_pdgId[1]) == 11)*(Lepton_tightElectron_{eleWP}_TotSF_Down[1])/(Lepton_tightElectron_{eleWP}_TotSF[1])+
+                                               (abs(Lepton_pdgId[1]) == 13)) 
+                                              : 0.0
+                                           """
+
+  formulas[f"LepSF3l__ele_{eleWP}__Up"] = f"""(nLepton > 2) ?
+                                              ((abs(Lepton_pdgId[0]) == 11)*(Lepton_tightElectron_{eleWP}_TotSF_Up[0])/(Lepton_tightElectron_{eleWP}_TotSF[0])+
+                                               (abs(Lepton_pdgId[0]) == 13)) *
+                                              ((abs(Lepton_pdgId[1]) == 11)*(Lepton_tightElectron_{eleWP}_TotSF_Up[1])/(Lepton_tightElectron_{eleWP}_TotSF[1])+
+                                               (abs(Lepton_pdgId[1]) == 13)) *
+                                              ((abs(Lepton_pdgId[2]) == 11)*(Lepton_tightElectron_{eleWP}_TotSF_Up[2])/(Lepton_tightElectron_{eleWP}_TotSF[2])+
+                                               (abs(Lepton_pdgId[2]) == 13))
+                                              : 0.0
+                                           """
+
+  formulas[f"LepSF3l__ele_{eleWP}__Do"] = f"""(nLepton > 2) ?
+                                              ((abs(Lepton_pdgId[0]) == 11)*(Lepton_tightElectron_{eleWP}_TotSF_Down[0])/(Lepton_tightElectron_{eleWP}_TotSF[0])+
+                                               (abs(Lepton_pdgId[0]) == 13)) *
+                                              ((abs(Lepton_pdgId[1]) == 11)*(Lepton_tightElectron_{eleWP}_TotSF_Down[1])/(Lepton_tightElectron_{eleWP}_TotSF[1])+
+                                               (abs(Lepton_pdgId[1]) == 13)) *
+                                              ((abs(Lepton_pdgId[2]) == 11)*(Lepton_tightElectron_{eleWP}_TotSF_Down[2])/(Lepton_tightElectron_{eleWP}_TotSF[2])+
+                                               (abs(Lepton_pdgId[2]) == 13))
+                                              : 0.0
+                                           """
+
+  formulas[f"LepSF4l__ele_{eleWP}__Up"] = f"""(nLepton > 3) ?
+                                              ((abs(Lepton_pdgId[0]) == 11)*(Lepton_tightElectron_{eleWP}_TotSF_Up[0])/(Lepton_tightElectron_{eleWP}_TotSF[0])+
+                                               (abs(Lepton_pdgId[0]) == 13)) *
+                                              ((abs(Lepton_pdgId[1]) == 11)*(Lepton_tightElectron_{eleWP}_TotSF_Up[1])/(Lepton_tightElectron_{eleWP}_TotSF[1])+
+                                               (abs(Lepton_pdgId[1]) == 13)) *
+                                              ((abs(Lepton_pdgId[2]) == 11)*(Lepton_tightElectron_{eleWP}_TotSF_Up[2])/(Lepton_tightElectron_{eleWP}_TotSF[2])+
+                                               (abs(Lepton_pdgId[2]) == 13)) *
+                                              ((abs(Lepton_pdgId[3]) == 11)*(Lepton_tightElectron_{eleWP}_TotSF_Up[3])/(Lepton_tightElectron_{eleWP}_TotSF[3])+
+                                               (abs(Lepton_pdgId[3]) == 13))
+                                              : 0.0
+                                           """
+
+  formulas[f"LepSF4l__ele_{eleWP}__Do"] = f"""(nLepton > 3) ?
+                                              ((abs(Lepton_pdgId[0]) == 11)*(Lepton_tightElectron_{eleWP}_TotSF_Down[0])/(Lepton_tightElectron_{eleWP}_TotSF[0])+
+                                               (abs(Lepton_pdgId[0]) == 13)) *
+                                              ((abs(Lepton_pdgId[1]) == 11)*(Lepton_tightElectron_{eleWP}_TotSF_Down[1])/(Lepton_tightElectron_{eleWP}_TotSF[1])+
+                                               (abs(Lepton_pdgId[1]) == 13)) *
+                                              ((abs(Lepton_pdgId[2]) == 11)*(Lepton_tightElectron_{eleWP}_TotSF_Down[2])/(Lepton_tightElectron_{eleWP}_TotSF[2])+
+                                               (abs(Lepton_pdgId[2]) == 13)) *
+                                              ((abs(Lepton_pdgId[3]) == 11)*(Lepton_tightElectron_{eleWP}_TotSF_Down[3])/(Lepton_tightElectron_{eleWP}_TotSF[3])+
+                                               (abs(Lepton_pdgId[3]) == 13))
+                                              : 0.0
+                                           """
+
+for muWP in muWPlist:
+  formulas[f"LepSF2l__mu_{muWP}__Up"] = f"""(nLepton > 1) ?
+                                            ((abs(Lepton_pdgId[0]) == 13)*(Lepton_tightMuon_{muWP}_TotSF_Up[0])/(Lepton_tightMuon_{muWP}_TotSF[0])+
+                                             (abs(Lepton_pdgId[0]) == 11)) *
+                                            ((abs(Lepton_pdgId[1]) == 13)*(Lepton_tightMuon_{muWP}_TotSF_Up[1])/(Lepton_tightMuon_{muWP}_TotSF[1])+
+                                             (abs(Lepton_pdgId[1]) == 11))
+                                            : 0.0
+                                         """
+  
+  formulas[f"LepSF2l__mu_{muWP}__Do"] = f"""(nLepton > 1) ?
+                                            ((abs(Lepton_pdgId[0]) == 13)*(Lepton_tightMuon_{muWP}_TotSF_Down[0])/(Lepton_tightMuon_{muWP}_TotSF[0])+
+                                             (abs(Lepton_pdgId[0]) == 11)) *
+                                            ((abs(Lepton_pdgId[1]) == 13)*(Lepton_tightMuon_{muWP}_TotSF_Down[1])/(Lepton_tightMuon_{muWP}_TotSF[1])+
+                                             (abs(Lepton_pdgId[1]) == 11))
+                                            : 0.0
+                                         """
+                                          
+  formulas[f"LepSF3l__mu_{muWP}__Up"] = f"""(nLepton > 2) ?
+                                            ((abs(Lepton_pdgId[0]) == 13)*(Lepton_tightMuon_{muWP}_TotSF_Up[0])/(Lepton_tightMuon_{muWP}_TotSF[0])+
+                                             (abs(Lepton_pdgId[0]) == 11)) *
+                                            ((abs(Lepton_pdgId[1]) == 13)*(Lepton_tightMuon_{muWP}_TotSF_Up[1])/(Lepton_tightMuon_{muWP}_TotSF[1])+
+                                             (abs(Lepton_pdgId[1]) == 11)) *
+                                            ((abs(Lepton_pdgId[2]) == 13)*(Lepton_tightMuon_{muWP}_TotSF_Up[2])/(Lepton_tightMuon_{muWP}_TotSF[2])+
+                                             (abs(Lepton_pdgId[2]) == 11))
+                                            : 0.0
+                                         """
+  
+  formulas[f"LepSF3l__mu_{muWP}__Do"] = f"""(nLepton > 2) ?
+                                            ((abs(Lepton_pdgId[0]) == 13)*(Lepton_tightMuon_{muWP}_TotSF_Down[0])/(Lepton_tightMuon_{muWP}_TotSF[0])+
+                                             (abs(Lepton_pdgId[0]) == 11)) *
+                                            ((abs(Lepton_pdgId[1]) == 13)*(Lepton_tightMuon_{muWP}_TotSF_Down[1])/(Lepton_tightMuon_{muWP}_TotSF[1])+
+                                             (abs(Lepton_pdgId[1]) == 11)) *
+                                            ((abs(Lepton_pdgId[2]) == 13)*(Lepton_tightMuon_{muWP}_TotSF_Down[2])/(Lepton_tightMuon_{muWP}_TotSF[2])+
+                                             (abs(Lepton_pdgId[2]) == 11))
+                                            : 0.0
+                                         """
+  
+  formulas[f"LepSF4l__mu_{muWP}__Up"] = f"""(nLepton > 3) ?
+                                            ((abs(Lepton_pdgId[0]) == 13)*(Lepton_tightMuon_{muWP}_TotSF_Up[0])/(Lepton_tightMuon_{muWP}_TotSF[0])+
+                                             (abs(Lepton_pdgId[0]) == 11)) *
+                                            ((abs(Lepton_pdgId[1]) == 13)*(Lepton_tightMuon_{muWP}_TotSF_Up[1])/(Lepton_tightMuon_{muWP}_TotSF[1])+
+                                             (abs(Lepton_pdgId[1]) == 11)) *
+                                            ((abs(Lepton_pdgId[2]) == 13)*(Lepton_tightMuon_{muWP}_TotSF_Up[2])/(Lepton_tightMuon_{muWP}_TotSF[2])+
+                                             (abs(Lepton_pdgId[2]) == 11)) *
+                                            ((abs(Lepton_pdgId[3]) == 13)*(Lepton_tightMuon_{muWP}_TotSF_Up[3])/(Lepton_tightMuon_{muWP}_TotSF[3])+
+                                             (abs(Lepton_pdgId[3]) == 11))
+                                            : 0.0
+                                         """
+  
+  formulas[f"LepSF4l__mu_{muWP}__Do"] = f"""(nLepton > 3) ?
+                                            ((abs(Lepton_pdgId[0]) == 13)*(Lepton_tightMuon_{muWP}_TotSF_Down[0])/(Lepton_tightMuon_{muWP}_TotSF[0])+
+                                             (abs(Lepton_pdgId[0]) == 11)) *
+                                            ((abs(Lepton_pdgId[1]) == 13)*(Lepton_tightMuon_{muWP}_TotSF_Down[1])/(Lepton_tightMuon_{muWP}_TotSF[1])+
+                                             (abs(Lepton_pdgId[1]) == 11)) *
+                                            ((abs(Lepton_pdgId[2]) == 13)*(Lepton_tightMuon_{muWP}_TotSF_Down[2])/(Lepton_tightMuon_{muWP}_TotSF[2])+
+                                             (abs(Lepton_pdgId[2]) == 11)) *
+                                            ((abs(Lepton_pdgId[3]) == 13)*(Lepton_tightMuon_{muWP}_TotSF_Down[3])/(Lepton_tightMuon_{muWP}_TotSF[3])+
+                                             (abs(Lepton_pdgId[3]) == 11))
+                                            : 0.0
+                                         """
+
+formulas["GenLepMatch2l"] = "(nLepton > 1) ? Lepton_genmatched[0]*Lepton_genmatched[1] : 0.0"
+
+formulas["GenLepMatch3l"] = "(nLepton > 2) ? Lepton_genmatched[0]*Lepton_genmatched[1]*Lepton_genmatched[2] : 0.0"
+
+formulas["GenLepMatch4l"] = "(nLepton > 3) ? Lepton_genmatched[0]*Lepton_genmatched[1]*Lepton_genmatched[2]*Lepton_genmatched[3] : 0.0"

--- a/mkShapesRDF/processor/framework/Steps_cfg.py
+++ b/mkShapesRDF/processor/framework/Steps_cfg.py
@@ -56,7 +56,7 @@ Steps = {
             "l2Kin",
             "l3Kin",
             "l4Kin",
-            "formulasMC2018v9",
+            "formulasMC2017v9",
             "finalSnapshot_JES_17",
         ],
         "outputFolder": "MCl1loose2017v9__MCCorr2017v9NoJERInHorn__l2tightOR2017v9__RDF",
@@ -259,7 +259,7 @@ Steps = {
         "do4MC": True,
         "do4Data": False,
         "import": "mkShapesRDF.processor.modules.JMECalculator",
-        "declare": 'jmeCalculator = lambda : JMECalculator("Summer19UL17_V6_MC", "Summer19UL17_JRV2_MC", \
+        "declare": 'jmeCalculator = lambda : JMECalculator("Summer19UL17_V5_MC", "Summer19UL17_JRV2_MC", \
             jet_object="AK4PFchs", do_Jets=True, do_MET=True, do_Unclustered=False, met_collections = ["PuppiMET", "MET", "RawMET"],\
             do_JER=False, store_nominal=False, store_variations=True)',
         "module": "jmeCalculator()",
@@ -297,6 +297,14 @@ Steps = {
         "import": "mkShapesRDF.processor.modules.l4KinProducer",
         "declare": "l4Kin = lambda : l4KinProducer()",
         "module": "l4Kin()",
+    },
+    "formulasMC2017v9": {
+        "isChain": False,
+        "do4MC": True,
+        "do4Data": False,
+        "import": "mkShapesRDF.processor.modules.GenericFormulaAdder",
+        "declare": "formulasMC2017v9 = lambda : GenericFormulaAdder(pathToConfigFile='RPLME_FW/processor/data/formulasToAdd_MC_Full2017v9.py')",
+        "module": "formulasMC2017v9()",
     },
     "formulasMC2018v9": {
         "isChain": False,

--- a/mkShapesRDF/processor/framework/samples/Run2017_UL2017_nAODv9.py
+++ b/mkShapesRDF/processor/framework/samples/Run2017_UL2017_nAODv9.py
@@ -1,0 +1,31 @@
+Samples = {}
+
+Samples["DoubleEG_Run2017B-UL2017-v1"] = {'nanoAOD': '/DoubleEG/Run2017B-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD'}
+Samples["DoubleEG_Run2017C-UL2017-v1"] = {'nanoAOD': '/DoubleEG/Run2017C-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD'}
+Samples["DoubleEG_Run2017D-UL2017-v1"] = {'nanoAOD': '/DoubleEG/Run2017D-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD'}
+Samples["DoubleEG_Run2017E-UL2017-v1"] = {'nanoAOD': '/DoubleEG/Run2017E-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD'}
+Samples["DoubleEG_Run2017F-UL2017-v1"] = {'nanoAOD': '/DoubleEG/Run2017F-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD'}
+
+Samples["DoubleMuon_Run2017B-UL2017-v1"] = {'nanoAOD': '/DoubleMuon/Run2017B-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD'}
+Samples["DoubleMuon_Run2017C-UL2017-v1"] = {'nanoAOD': '/DoubleMuon/Run2017C-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD'}
+Samples["DoubleMuon_Run2017D-UL2017-v1"] = {'nanoAOD': '/DoubleMuon/Run2017D-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD'}
+Samples["DoubleMuon_Run2017E-UL2017-v1"] = {'nanoAOD': '/DoubleMuon/Run2017E-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD'}
+Samples["DoubleMuon_Run2017F-UL2017-v1"] = {'nanoAOD': '/DoubleMuon/Run2017F-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD'}
+
+Samples["MuonEG_Run2017B-UL2017-v1"] = {'nanoAOD': '/MuonEG/Run2017B-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD'}
+Samples["MuonEG_Run2017C-UL2017-v1"] = {'nanoAOD': '/MuonEG/Run2017C-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD'}
+Samples["MuonEG_Run2017D-UL2017-v1"] = {'nanoAOD': '/MuonEG/Run2017D-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD'}
+Samples["MuonEG_Run2017E-UL2017-v1"] = {'nanoAOD': '/MuonEG/Run2017E-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD'}
+Samples["MuonEG_Run2017F-UL2017-v1"] = {'nanoAOD': '/MuonEG/Run2017F-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD'}
+
+Samples["SingleElectron_Run2017B-UL2017-v1"] = {'nanoAOD': '/SingleElectron/Run2017B-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD'}
+Samples["SingleElectron_Run2017C-UL2017-v1"] = {'nanoAOD': '/SingleElectron/Run2017C-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD'}
+Samples["SingleElectron_Run2017D-UL2017-v1"] = {'nanoAOD': '/SingleElectron/Run2017D-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD'}
+Samples["SingleElectron_Run2017E-UL2017-v1"] = {'nanoAOD': '/SingleElectron/Run2017E-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD'}
+Samples["SingleElectron_Run2017F-UL2017-v1"] = {'nanoAOD': '/SingleElectron/Run2017F-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD'}
+
+Samples["SingleMuon_Run2017B-UL2017-v1"] = {'nanoAOD': '/SingleMuon/Run2017B-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD'}
+Samples["SingleMuon_Run2017C-UL2017-v1"] = {'nanoAOD': '/SingleMuon/Run2017C-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD'}
+Samples["SingleMuon_Run2017D-UL2017-v1"] = {'nanoAOD': '/SingleMuon/Run2017D-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD'}
+Samples["SingleMuon_Run2017E-UL2017-v1"] = {'nanoAOD': '/SingleMuon/Run2017E-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD'}
+Samples["SingleMuon_Run2017F-UL2017-v1"] = {'nanoAOD': '/SingleMuon/Run2017F-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD'}

--- a/mkShapesRDF/processor/framework/samples/Summer20UL17_106x_nAODv9.py
+++ b/mkShapesRDF/processor/framework/samples/Summer20UL17_106x_nAODv9.py
@@ -1,0 +1,674 @@
+Samples = {}
+
+# Signals
+#--->Updated!###-----------------------------------------------##
+Samples['GluGluHToTauTau_M125'] = {'nanoAOD' :'/GluGluHToTauTau_M125_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['GluGluHToTauTau_M125_FXFX'] = {'nanoAOD' :'/GluGluHToTauTau_M-125_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['VBFHToTauTau_M125'] = {'nanoAOD' :'/VBFHToTauTau_M125_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'} ##!!!!
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['VBFHToWWTo2L2Nu_M125'] = {'nanoAOD' :'/VBFHToWWTo2L2Nu_M-125_TuneCP5_13TeV-powheg-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+Samples['VBFHToWWTo2L2Nu_M125_noPDF'] = {'nanoAOD' :'/VBFHToWWTo2L2Nu_M125_TuneCP5_13TeV_powheg2_JHUGenV714_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['HZJ_HToWWTo2L2Nu_ZTo2L_M125'] = {'nanoAOD' :'/HZJ_HToWWTo2L2Nu_ZTo2L_M-125_TuneCP5_13TeV-powheg-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'} ##!!!!
+Samples['HZJ_HToWW_M125'] = {'nanoAOD' : '/HZJ_HToWW_M-125_TuneCP5_13TeV-powheg-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+Samples['HZJ_HToWW_M125_ext1'] = {'nanoAOD' : '/HZJ_HToWW_M-125_TuneCP5_13TeV-powheg-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9_ext1-v1/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['GluGluZH_HToWW_ZTo2L_M125'] = {'nanoAOD' :'/GluGluZH_HToWW_ZTo2L_M-125_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['GluGluZH_HToWWTo2L2Nu_M125'] = {'nanoAOD' :'/GluGluZH_HToWWTo2L2Nu_M-125_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['HWminusJ_HToWW_M125'] = {'nanoAOD' :'/HWminusJ_HToWW_M-125_TuneCP5_13TeV-powheg-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'} ##!!!!
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['HWplusJ_HToWW_M125'] = {'nanoAOD' :'/HWplusJ_HToWW_M-125_TuneCP5_13TeV-powheg-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+Samples['HWplusJ_HToWWTo2L2Nu_WTo2L_M125'] = {'nanoAOD' :'/HWplusJ_HToWWTo2L2Nu_WTo2L_M-125_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['ttHToNonbb_M125'] = {'nanoAOD' :'/ttHToNonbb_M125_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'} ##!!!!
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['GluGluHToWWTo2L2Nu_M125'] = {'nanoAOD' :'/GluGluHToWWTo2L2Nu_M-125_TuneCP5_13TeV-powheg-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+Samples['GluGluHToWWTo2L2Nu_M125_Powheg'] = {'nanoAOD' :'/GluGluHToWWTo2L2Nu_M-125_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+Samples['GluGluHToWWTo2L2Nu_M125_TuneCP5Down'] = {'nanoAOD' :'/GluGluHToWWTo2L2Nu_M-125_TuneCP5Down_13TeV-powheg-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['GluGluHToWWTo2L2Nu_M125_Powheg_noPDF'] = {'nanoAOD' :'/GluGluHToWWTo2L2Nu_M125_TuneCP5_PSw_13TeV-powheg2-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+Samples['GluGluHToWWTo2L2Nu_M125_noPDF'] = {'nanoAOD' :'/GluGluHToWWTo2L2Nu_M125_TuneCP5_13TeV_powheg2_JHUGenV714_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+Samples['GGHjjToWWTo2L2Nu_minloHJJ_M125'] = {'nanoAOD' :'/GluGluHToWWTo2L2N_M-125_TuneCP5_minloHJJ_13TeV-powheg-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['VBFHToWWTo2L2Nu_M125'] = {'nanoAOD' :'/VBFHToWWTo2L2Nu_M-125_TuneCP5_13TeV-powheg-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+Samples['VBFHToWWTo2L2Nu_M125_TuneCP5Up'] = {'nanoAOD' :'/VBFHToWWTo2L2Nu_M-125_TuneCP5Up_13TeV-powheg-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['VBFHToWWTo2L2Nu_M125_TuneCP5Down'] = {'nanoAOD' :'/VBFHToWWTo2L2Nu_M-125_TuneCP5Down_13TeV-powheg-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['VBFHToWWTo2L2Nu_M125_noPDF'] = {'nanoAOD' :'/VBFHToWWTo2L2Nu_M125_TuneCP5_13TeV_powheg2_JHUGenV714_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+##---------------------------------------------------------------##
+
+#--->Updated!###-----------------------------------------------##
+Samples['WGToLNuG'] = {'nanoAOD' :'/WGToLNuG_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['Wg_AMCNLOFXFX_01J_PDF'] = {'nanoAOD' :'/WGToLNuG_01J_5f_PDFWeights_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['Wg_AMCNLOFXFX_01J'] = {'nanoAOD' :'/WGToLNuG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['WWTo2L2Nu'] = {'nanoAOD' :'/WWTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['WWTo2L2Nu_TuneCP5Down'] = {'nanoAOD' :'/WWTo2L2Nu_TuneCP5Down_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'} ##!!!!
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['WWTo2L2Nu_TuneCP5Up'] = {'nanoAOD' :'/WWTo2L2Nu_TuneCP5Up_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'} ##!!!!
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['GluGluToWWToENEN'] = {'nanoAOD' :'/GluGluToWWToENEN_TuneCP5_13TeV_MCFM701_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'} ##!!!!
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['GluGluToWWToENMN'] = {'nanoAOD' :'/GluGluToWWToENMN_TuneCP5_13TeV_MCFM701_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'} ##!!!!
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['GluGluToWWToMNEN'] = {'nanoAOD' :'/GluGluToWWToMNEN_TuneCP5_13TeV_MCFM701_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'} ##!!!!
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['GluGluToWWToMNMN'] = {'nanoAOD' :'/GluGluToWWToMNMN_TuneCP5_13TeV_MCFM701_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'} ##!!!!
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['GluGluToWWToMNTN'] = {'nanoAOD' :'/GluGluToWWToMNTN_TuneCP5_13TeV_MCFM701_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'} ##!!!!
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['GluGluToWWToENTN'] = {'nanoAOD' :'/GluGluToWWToENTN_TuneCP5_13TeV_MCFM701_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'} ##!!!!
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['GluGluToWWToTNEN'] = {'nanoAOD' :'/GluGluToWWToTNEN_TuneCP5_13TeV_MCFM701_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'} ##!!!!
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['GluGluToWWToTNMN'] = {'nanoAOD' :'/GluGluToWWToTNMN_TuneCP5_13TeV_MCFM701_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'} ##!!!!
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['GluGluToWWToTNTN'] = {'nanoAOD' :'/GluGluToWWToTNTN_TuneCP5_13TeV_MCFM701_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'} ##!!!!
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['WZG'] = {'nanoAOD' :'/WZG_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['WZ'] = {'nanoAOD' :'/WZ_TuneCP5_13TeV-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['WZTo3LNu_mllmin4p0'] = {'nanoAOD' :'/WZTo3LNu_mllmin4p0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+Samples['WZTo3LNu_mllmin0p1'] = {'nanoAOD' :'/WZTo3LNu_mllmin0p1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+Samples['WZTo3LNu'] = {'nanoAOD' :'/WZTo3LNu_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+Samples['WZTo2Q2L_mllmin4p0'] = {'nanoAOD' :'/WZTo2Q2L_mllmin4p0_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['ZZ'] = {'nanoAOD' :'/ZZ_TuneCP5_13TeV-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['ZZGTo4L'] = {'nanoAOD' :'/ZZGTo4L_TuneCP5_4f_NLO_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+Samples['ZZTo2Q2L_mllmin4p0'] = {'nanoAOD' :'/ZZTo2Q2L_mllmin4p0_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['ZZTo2L2Nu'] = {'nanoAOD' :'/ZZTo2L2Nu_TuneCP5_13TeV_powheg_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['ZZTo4L'] = {'nanoAOD' :'/ZZTo4L_TuneCP5_13TeV_powheg_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+Samples['ZZTo4L_M-1toInf'] = {'nanoAOD' :'/ZZTo4L_M-1toInf_TuneCP5_13TeV_powheg_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['ZGToLLG'] = {'nanoAOD' :'/ZGToLLG_01J_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'} ##!!!!
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['QCD_Pt_30to80_bcToE'] = {'nanoAOD' :'/QCD_Pt_30to80_bcToE_TuneCP5_13TeV_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'} ##!!!!
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['QCD_Pt_80to170_bcToE'] = {'nanoAOD' :'/QCD_Pt_80to170_bcToE_TuneCP5_13TeV_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'} ##!!!!
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['QCD_Pt_170to250_bcToE'] = {'nanoAOD' :'/QCD_Pt_170to250_bcToE_TuneCP5_13TeV_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'} ##!!!!
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['QCD_Pt_250toInf_bcToE'] = {'nanoAOD' :'/QCD_Pt_250toInf_bcToE_TuneCP5_13TeV_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'} ##!!!!
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['QCD_Pt_15to30'] = {'nanoAOD' :'/QCD_Pt_15to30_TuneCP5_13TeV_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['QCD_Pt_30to50'] = {'nanoAOD' :'/QCD_Pt_30to50_TuneCP5_13TeV_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['TTTo2L2Nu'] = {'nanoAOD' :'/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['TTTo2L2Nu_TuneCP5Up'] = {'nanoAOD' :'/TTTo2L2Nu_TuneCP5up_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['TTTo2L2Nu_TuneCP5Down'] = {'nanoAOD' :'/TTTo2L2Nu_TuneCP5down_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['TTTo2L2Nu_hdampUp'] = {'nanoAOD' :'/TTTo2L2Nu_hdampUP_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['TTTo2L2Nu_hdampDown'] = {'nanoAOD' :'/TTTo2L2Nu_hdampDOWN_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['TTToSemiLeptonic'] = {'nanoAOD' :'/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['TTToSemiLeptonic_TuneCP5Up'] = {'nanoAOD' :'/TTToSemiLeptonic_TuneCP5up_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['TTToSemiLeptonic_TuneCP5Down'] = {'nanoAOD' :'/TTToSemiLeptonic_TuneCP5down_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['TTToSemiLeptonic_hdampUp'] = {'nanoAOD' :'/TTToSemiLeptonic_hdampUP_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['TTToSemiLeptonic_hdampDown'] = {'nanoAOD' :'/TTToSemiLeptonic_hdampDOWN_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['ST_t-channel_top'] = {'nanoAOD' :'/ST_t-channel_top_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['ST_t-channel_top_TuneCP5Up'] = {'nanoAOD' :'/ST_t-channel_top_4f_InclusiveDecays_TuneCP5up_13TeV-powheg-madspin-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['ST_t-channel_top_TuneCP5Down'] = {'nanoAOD' :'/ST_t-channel_top_4f_InclusiveDecays_TuneCP5down_13TeV-powheg-madspin-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['ST_t-channel_top_hdampUp'] = {'nanoAOD' :'/ST_t-channel_top_4f_hdampup_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['ST_t-channel_top_hdampDown'] = {'nanoAOD' :'/ST_t-channel_top_4f_hdampdown_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['ST_t-channel_antitop'] = {'nanoAOD' :'/ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['ST_t-channel_antitop_TuneCP5Up'] = {'nanoAOD' :'/ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5up_13TeV-powheg-madspin-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['ST_t-channel_antitop_TuneCP5Down'] = {'nanoAOD' :'/ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5down_13TeV-powheg-madspin-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['ST_t-channel_antitop_hdampUp'] = {'nanoAOD' :'/ST_t-channel_antitop_4f_hdampup_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['ST_t-channel_antitop_hdampDown'] = {'nanoAOD' :'/ST_t-channel_antitop_4f_hdampdown_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['ST_tW_antitop'] = {'nanoAOD' :'/ST_tW_antitop_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+Samples['ST_tW_antitop_noHad'] = {'nanoAOD' :'/ST_tW_antitop_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['ST_tW_antitop_noHad_TuneCP5Up'] = {'nanoAOD' :'/ST_tW_antitop_5f_NoFullyHadronicDecays_TuneCP5up_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['ST_tW_antitop_noHad_TuneCP5Down'] = {'nanoAOD' :'/ST_tW_antitop_5f_NoFullyHadronicDecays_TuneCP5down_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+Samples['ST_tW_antitop_noHad_hdampUp'] = {'nanoAOD' :'/ST_tW_antitop_5f_hdampup_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+Samples['ST_tW_antitop_noHad_hdampDown'] = {'nanoAOD' :'/ST_tW_antitop_5f_hdampdown_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+Samples['ST_tW_antitop_noHad_PDF'] = {'nanoAOD' :'/ST_tW_antitop_5f_NoFullyHadronicDecays_TuneCP5_13TeV_PDFWeights-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['ST_tW_top'] = {'nanoAOD' :'/ST_tW_top_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+Samples['ST_tW_top_noHad'] = {'nanoAOD' :'/ST_tW_top_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['ST_tW_top_noHad_TuneCP5Up'] = {'nanoAOD' :'/ST_tW_top_5f_NoFullyHadronicDecays_TuneCP5up_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['ST_tW_top_noHad_TuneCP5Down'] = {'nanoAOD' :'/ST_tW_top_5f_NoFullyHadronicDecays_TuneCP5down_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['ST_tW_top_hdampUp'] = {'nanoAOD' :'/ST_tW_top_5f_hdampup_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+Samples['ST_tW_top_hdampDown'] = {'nanoAOD' :'/ST_tW_top_5f_hdampdown_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+Samples['ST_tW_top_noHad_PDF'] = {'nanoAOD' :'/ST_tW_top_5f_NoFullyHadronicDecays_TuneCP5_13TeV_PDFWeights-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['ST_s-channel'] = {'nanoAOD' :'/ST_s-channel_4f_leptonDecays_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-20UL17JMENano_106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['ST_s-channel_TuneCP5Up'] = {'nanoAOD' :'/ST_s-channel_4f_leptonDecays_TuneCP5up_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+Samples['ST_s-channel_TuneCP5Down'] = {'nanoAOD' :'/ST_s-channel_4f_leptonDecays_TuneCP5down_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['WJetsToLNu-LO'] = {'nanoAOD' :'/WJetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['WJetsToLNu'] = {'nanoAOD' :'/WJetsToLNu_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+Samples['WJetsToLNu_Sherpa'] = {'nanoAOD' :'/WJetsToLNu_012JetsNLO_34JetsLO_EWNLOcorr_13TeV-sherpa/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+
+Samples['WJetsToLNu_Pt-100To250'] = {'nanoAOD' :'/WJetsToLNu_Pt-100To250_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['WJetsToLNu_Pt-250To400'] = {'nanoAOD' :'/WJetsToLNu_Pt-250To400_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['WJetsToLNu_Pt-400To600'] = {'nanoAOD' :'/WJetsToLNu_Pt-400To600_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['WJetsToLNu_Pt-600ToInf'] = {'nanoAOD' :'/WJetsToLNu_Pt-600ToInf_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+
+Samples['WJetsToLNu_HT70To100'] = {'nanoAOD' :'/WJetsToLNu_HT-70To100_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['WJetsToLNu_HT100To200'] = {'nanoAOD' :'/WJetsToLNu_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['WJetsToLNu_HT200To400'] = {'nanoAOD' :'/WJetsToLNu_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['WJetsToLNu_HT400To600'] = {'nanoAOD' :'/WJetsToLNu_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['WJetsToLNu_HT600To800'] = {'nanoAOD' :'/WJetsToLNu_HT-600To800_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['WJetsToLNu_HT800To1200'] = {'nanoAOD' :'/WJetsToLNu_HT-800To1200_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v3/NANOAODSIM'}
+Samples['WJetsToLNu_HT1200To2500'] = {'nanoAOD' :'/WJetsToLNu_HT-1200To2500_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['WJetsToLNu_HT2500ToInf'] = {'nanoAOD' :'/WJetsToLNu_HT-2500ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+
+Samples['WJetsToLNu_0J'] = {'nanoAOD' :'/WJetsToLNu_0J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['WJetsToLNu_1J'] = {'nanoAOD' :'/WJetsToLNu_1J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['WJetsToLNu_2J'] = {'nanoAOD' :'/WJetsToLNu_2J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['TTZToLLNuNu_M-10'] = {'nanoAOD' :'/TTZToLLNuNu_M-10_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['TTZToLLNuNu_M-10_TuneCP5Up'] = {'nanoAOD' :'/TTZToLLNuNu_M-10_TuneCP5up_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+Samples['TTZToLLNuNu_M-10_TuneCP5Down'] = {'nanoAOD' :'/TTZToLLNuNu_M-10_TuneCP5down_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['tZq_ll'] = {'nanoAOD' :'/tZq_ll_4f_ckm_NLO_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['tZq_ll_TuneCP5Up'] = {'nanoAOD' :'/tZq_ll_4f_ckm_NLO_TuneCP5down_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+Samples['tZq_ll_TuneCP5Down'] = {'nanoAOD' :'/tZq_ll_4f_ckm_NLO_TuneCP5up_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['DYJetsToLL_M-10to50-LO'] = {'nanoAOD' :'/DYJetsToLL_M-10to50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['DYJetsToLL_M-10to50_NLO'] = {'nanoAOD' :'/DYJetsToLL_M-10to50_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['DYJetsToLL_M-50-LO'] = {'nanoAOD' :'/DYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['DYJetsToLL_M-50-LO_ext1'] = {'nanoAOD' :'/DYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9_ext1-v1/NANOAODSIM'}
+Samples['DYJetsToLL_M-50'] = {'nanoAOD' :'/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['DYJetsToTT_MuEle_M-50'] = {'nanoAOD' :'/DYJetsToTauTau_TauToMuEle_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['DYJetsToLL_M-50_HT-70to100'] = {'nanoAOD' :'/DYJetsToLL_M-50_HT-70to100_TuneCP5_PSweights_13TeV-madgraphMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'} ##!!!!
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['DYJetsToLL_M-50_HT-100to200'] = {'nanoAOD' :'/DYJetsToLL_M-50_HT-100to200_TuneCP5_PSweights_13TeV-madgraphMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'} ##!!!!
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['DYJetsToLL_M-50_HT-200to400'] = {'nanoAOD' :'/DYJetsToLL_M-50_HT-200to400_TuneCP5_PSweights_13TeV-madgraphMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'} ##!!!!
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['DYJetsToLL_M-50_HT-400to600'] = {'nanoAOD' :'/DYJetsToLL_M-50_HT-400to600_TuneCP5_PSweights_13TeV-madgraphMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'} ##!!!!
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['DYJetsToLL_M-50_HT-600to800'] = {'nanoAOD' :'/DYJetsToLL_M-50_HT-600to800_TuneCP5_PSweights_13TeV-madgraphMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'} ##!!!!
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['DYJetsToLL_M-50_HT-800to1200'] = {'nanoAOD' :'/DYJetsToLL_M-50_HT-800to1200_TuneCP5_PSweights_13TeV-madgraphMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'} ##!!!!
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['DYJetsToLL_M-50_HT-1200to2500'] = {'nanoAOD' :'/DYJetsToLL_M-50_HT-1200to2500_TuneCP5_PSweights_13TeV-madgraphMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'} ##!!!!
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['DYJetsToLL_M-50_HT-2500toInf'] = {'nanoAOD' :'/DYJetsToLL_M-50_HT-2500toInf_TuneCP5_PSweights_13TeV-madgraphMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'} ##!!!!
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['WWW'] = {'nanoAOD' :'/WWW_4F_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['WWW_ext1'] = {'nanoAOD' :'/WWW_4F_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9_ext1-v2/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['WWW_DiLeptonFilter'] = {'nanoAOD' :'/WWW_4F_DiLeptonFilter_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'} ##!!!!
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['WWZ'] = {'nanoAOD' :'/WWZ_4F_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['WWZ_ext1'] = {'nanoAOD' :'/WWZ_4F_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9_ext1-v2/NANOAODSIM'}
+Samples['WWZTo4L2Nu'] = {'nanoAOD' :'/WWZJetsTo4L2Nu_4F_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['WZZ'] = {'nanoAOD' :'/WZZ_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['WZZ_ext1'] = {'nanoAOD' :'/WZZ_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9_ext1-v2/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['ZZZ'] = {'nanoAOD' :'/ZZZ_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['ZZZ_ext1'] = {'nanoAOD' :'/ZZZ_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9_ext1-v2/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['WWG'] = {'nanoAOD' :'/WWG_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'} ##!!!!
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['QCD_HT200to300'] = {'nanoAOD' :'/QCD_HT200to300_TuneCP5_PSWeights_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['QCD_HT300to500'] = {'nanoAOD' :'/QCD_HT300to500_TuneCP5_PSWeights_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['QCD_HT700to1000'] = {'nanoAOD' :'/QCD_HT700to1000_TuneCP5_PSWeights_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['QCD_HT1000to1500'] = {'nanoAOD' :'/QCD_HT1000to1500_TuneCP5_PSWeights_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['TTJets-LO'] = {'nanoAOD' :'/TTJets_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['TTJets'] = {'nanoAOD' :'/TTJets_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['ST_t-channel_antitop_5f'] = {'nanoAOD' :'/ST_t-channel_antitop_5f_InclusiveDecays_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'} ##!!!!
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['ST_t-channel_top_5f'] = {'nanoAOD' :'/ST_t-channel_top_5f_InclusiveDecays_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['WZJJ_Inclusive'] = {'nanoAOD' :'/WZJJ_EWK_InclusivePolarization_TuneCP5_13TeV_madgraph-madspin-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'} ##!!!!
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['WZJJ_LL'] = {'nanoAOD' :'/WZJJ_EWK_LLPolarization_TuneCP5_13TeV_madgraph-madspin-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'} ##!!!!
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['WZJJ_TL'] = {'nanoAOD' :'/WZJJ_EWK_TLPolarization_TuneCP5_13TeV_madgraph-madspin-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'} ##!!!!
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['WZJJ_LT'] = {'nanoAOD' :'/WZJJ_EWK_LTPolarization_TuneCP5_13TeV_madgraph-madspin-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'} ##!!!!
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['WZJJ_TT'] = {'nanoAOD' :'/WZJJ_EWK_TTPolarization_TuneCP5_13TeV_madgraph-madspin-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'} ##!!!!
+##---------------------------------------------------------------##
+
+#--->Updated!###-----------------------------------------------##
+Samples['EWKZ2Jets_ZToLL_M-50_MJJ-120'] = {'nanoAOD' :'/EWK_LLJJ_MLL-50_MJJ-120_TuneCP5_13TeV-madgraph-pythia8_dipole/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'} ##!!!!
+
+Samples['EWKZ2Jets_ZToLL_M-50'] = {'nanoAOD' :'/EWKZ2Jets_ZToLL_M-50_TuneCP5_withDipoleRecoil_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'} ##!!!!
+
+
+
+# Signal
+#--->Updated!###-----------------------------------------------##
+Samples['WpWmJJ_EWK_noTop'] = {'nanoAOD' :'/WWJJToLNuLNu_EWK_noTop_TuneCP5_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'} ##!!!!
+#--->Updated!###-----------------------------------------------##
+Samples['SSWW'] = {'nanoAOD' :'/SSWW_TuneCP5_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['VBS_SSWW_cW_INT'] = {'nanoAOD' :'/VBS_SSWW_cW_INT_TuneCP5_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'} ##!!!!
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['VBS_SSWW_cHW_INT'] = {'nanoAOD' :'/VBS_SSWW_cHW_INT_TuneCP5_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'} ##!!!!
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['VBS_SSWW_cW_cHW'] = {'nanoAOD' :'/VBS_SSWW_cW_cHW_TuneCP5_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'} ##!!!!
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['H0PM_ToWWTo2L2Nu'] = {'nanoAOD' :'/Higgs0PMToWW_M-125_TuneCP5_13TeV-powheg-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+Samples['H0PH_ToWWTo2L2Nu'] = {'nanoAOD' :'/Higgs0PHToWW_M-125_TuneCP5_13TeV-powheg-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+Samples['H0PHf05_ToWWTo2L2Nu'] = {'nanoAOD' :'/Higgs0PHf05ph0ToWW_M-125_TuneCP5_13TeV-powheg-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+Samples['H0M_ToWWTo2L2Nu'] = {'nanoAOD' :'/Higgs0MToWW_M-125_TuneCP5_13TeV-powheg-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+Samples['H0Mf05_ToWWTo2L2Nu'] = {'nanoAOD' :'/Higgs0Mf05ph0ToWW_M-125_TuneCP5_13TeV-powheg-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+Samples['H0L1_ToWWTo2L2Nu'] = {'nanoAOD' :'/Higgs0L1ToWW_M-125_TuneCP5_13TeV-powheg-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+Samples['H0L1f05_ToWWTo2L2Nu'] = {'nanoAOD' :'/Higgs0L1f05ph0ToWW_M-125_TuneCP5_13TeV-powheg-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['VBF_H0PM_ToWWTo2L2Nu'] = {'nanoAOD' :'/VBFHiggs0PMToWWTo2L2Nu_M-125_TuneCP5_13TeV-powheg-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+Samples['VBF_H0PH_ToWWTo2L2Nu'] = {'nanoAOD' :'/VBFHiggs0PHToWWTo2L2Nu_M-125_TuneCP5_DipoleRecoil_13TeV-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['VBF_H0PHf05_ToWWTo2L2Nu'] = {'nanoAOD' :'/VBFHiggs0PHf05ph0ToWWTo2L2Nu_M-125_TuneCP5_DipoleRecoil_13TeV-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['VBF_H0M_ToWWTo2L2Nu'] = {'nanoAOD' :'/VBFHiggs0MToWWTo2L2Nu_M-125_TuneCP5_DipoleRecoil_13TeV-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['VBF_H0L1_ToWWTo2L2Nu'] = {'nanoAOD' :'/VBFHiggs0L1ToWWTo2L2Nu_M-125_TuneCP5_DipoleRecoil_13TeV-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['VBF_H0L1Zgf05_ToWWTo2L2Nu'] = {'nanoAOD' :'/VBFHiggs0L1Zgf05ph0ToWWTo2L2Nu_M-125_TuneCP5_DipoleRecoil_13TeV-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+##---------------------------------------------------------------##--->Updated!###-----------------------------------------------##
+Samples['WH_H0PM_ToWWTo2L2Nu'] = {'nanoAOD' :'/WHiggs0PMToWWToLNu_M-125_2LOSfilter_TuneCP5_13TeV-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['WH_H0PH_ToWWTo2L2Nu'] = {'nanoAOD' :'/WHiggs0PHToWWToLNu_M-125_2LOSfilter_TuneCP5_13TeV-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['WH_H0PHf05_ToWWTo2L2Nu'] = {'nanoAOD' :'/WHiggs0PHf05ph0ToWWToLNu_M-125_2LOSfilter_TuneCP5_13TeV-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['WH_H0M_ToWWTo2L2Nu'] = {'nanoAOD' :'/WHiggs0MToWWToLNu_M-125_2LOSfilter_TuneCP5_13TeV-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['WH_H0Mf05_ToWWTo2L2Nu'] = {'nanoAOD' :'/WHiggs0Mf05ph0ToWWToLNu_M-125_2LOSfilter_TuneCP5_13TeV-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['WH_H0L1_ToWWTo2L2Nu'] = {'nanoAOD' :'/WHiggs0L1ToWWToLNu_M-125_2LOSfilter_TuneCP5_13TeV-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['WH_H0L1f05_ToWWTo2L2Nu'] = {'nanoAOD' :'/WHiggs0L1f05ph0ToWWToLNu_M-125_2LOSfilter_TuneCP5_13TeV-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['ZH_H0PM_ToWWTo2L2Nu'] = {'nanoAOD' :'/ZHiggs0PMToWW_M-125_2Lfilter_TuneCP5_13TeV-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['ZH_H0PH_ToWWTo2L2Nu'] = {'nanoAOD' :'/ZHiggs0PHToWW_M-125_2Lfilter_TuneCP5_13TeV-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['ZH_H0PHf05_ToWWTo2L2Nu'] = {'nanoAOD' :'/ZHiggs0PHf05ph0ToWW_M-125_2Lfilter_TuneCP5_13TeV-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['ZH_H0M_ToWWTo2L2Nu'] = {'nanoAOD' :'/ZHiggs0MToWW_M-125_2Lfilter_TuneCP5_13TeV-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['ZH_H0Mf05_ToWWTo2L2Nu'] = {'nanoAOD' :'/ZHiggs0Mf05ph0ToWW_M-125_2Lfilter_TuneCP5_13TeV-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['ZH_H0L1_ToWWTo2L2Nu'] = {'nanoAOD' :'/ZHiggs0L1ToWW_M-125_2Lfilter_TuneCP5_13TeV-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['ZH_H0L1f05_ToWWTo2L2Nu'] = {'nanoAOD' :'/ZHiggs0L1f05ph0ToWW_M-125_2Lfilter_TuneCP5_13TeV-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['ZH_H0LZgf05_ToWWTo2L2Nu'] = {'nanoAOD' :'/ZHiggs0L1ToWW_M-125_2Lfilter_TuneCP5_13TeV-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['GGHjj_H0PM_ToWWTo2L2Nu'] = {'nanoAOD' :'/JJHiggs0PMToWWTo2L2Nu_M-125_TuneCP5_13TeV-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['GGHjj_H0M_ToWWTo2L2Nu'] = {'nanoAOD' :'/JJHiggs0MToWWTo2L2Nu_M-125_TuneCP5_13TeV-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['GGHjj_H0Mf05_ToWWTo2L2Nu'] = {'nanoAOD' :'/JJHiggs0Mf05ph0ToWWTo2L2Nu_M-125_TuneCP5_13TeV-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+##---------------------------------------------------------------##
+#--->Updated!###-----------------------------------------------##
+Samples['ttH_H0PM_ToWWTo2L2Nu'] = {'nanoAOD' :'/ttHiggs0PMToWWToLNu_2OSL_M-125_TuneCP5_13TeV-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['ttH_H0M_ToWWTo2L2Nu'] = {'nanoAOD' :'/ttHiggs0MToWWToLNu_2OSL_M-125_TuneCP5_13TeV-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['ttH_H0Mf05_ToWWTo2L2Nu'] = {'nanoAOD' :'/ttHiggs0Mf05ph0ToWWToLNu_2OSL_M-125_TuneCP5_13TeV-jhugen727-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+##---------------------------------------------------------------##
+Samples['WpWmJJ_EWK_noTop_pol_LL'] = {'nanoAOD' :'/VBS_OSWW_LL_noTop_TuneCP5_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['WpWmJJ_EWK_noTop_pol_LT'] = {'nanoAOD' :'/VBS_OSWW_LT_noTop_TuneCP5_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['WpWmJJ_EWK_noTop_pol_TL'] = {'nanoAOD' :'/VBS_OSWW_TL_noTop_TuneCP5_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['WpWmJJ_EWK_noTop_pol_TT'] = {'nanoAOD' :'/VBS_OSWW_TT_noTop_TuneCP5_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+
+Samples['WpWmJJ_EWK_noTop_CMWW_pol_LL'] = {'nanoAOD' :'/VBS_OSWW_LL_noTop_CMWW_TuneCP5_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['WpWmJJ_EWK_noTop_CMWW_pol_LT'] = {'nanoAOD' :'/VBS_OSWW_LT_noTop_CMWW_TuneCP5_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['WpWmJJ_EWK_noTop_CMWW_pol_TL'] = {'nanoAOD' :'/VBS_OSWW_TL_noTop_CMWW_TuneCP5_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['WpWmJJ_EWK_noTop_CMWW_pol_TT'] = {'nanoAOD' :'/VBS_OSWW_TT_noTop_CMWW_TuneCP5_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+
+Samples['WpWmJJ_EWK_noTop'] = {'nanoAOD' :'/WWJJToLNuLNu_EWK_noTop_TuneCP5_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['WpWmJJ_QCD_noTop'] = {'nanoAOD' :'/WWJJToLNuLNu_QCD_noTop_TuneCP5_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['WpWmJJ_EWK_QCD_noTop'] = {'nanoAOD' :'/WWJJToLNuLNu_OS_EWK_QCD_noTop_TuneCP5_13TeV_madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+
+Samples['ZHToTauTau_M125'] = {'nanoAOD' :'/ZHToTauTau_M125_CP5_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+Samples['ZHToTauTau_M125_ext1'] = {'nanoAOD' :'/ZHToTauTau_M125_CP5_13TeV-powheg-pythia8_ext1/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM'}
+
+Samples['WminusHToTauTau_M125'] = {'nanoAOD' :'/WminusHToTauTau_M125_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['WplusHToTauTau_M125'] = {'nanoAOD' :'/WplusHToTauTau_M125_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+
+##---------------------------------------------------------------------------##
+Samples['AToZHToLLTTbar_MA-1000_MH-330'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1000_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1000_MH-350'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1000_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1000_MH-400'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1000_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1000_MH-450'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1000_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1000_MH-500'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1000_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1000_MH-550'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1000_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1000_MH-600'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1000_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1000_MH-650'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1000_MH-650_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1000_MH-700'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1000_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1000_MH-750'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1000_MH-750_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1000_MH-800'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1000_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1000_MH-850'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1000_MH-850_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1000_MH-900'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1000_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1050_MH-330'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1050_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1050_MH-350'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1050_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1050_MH-400'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1050_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1050_MH-450'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1050_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1050_MH-500'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1050_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1050_MH-550'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1050_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1050_MH-600'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1050_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1050_MH-700'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1050_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1050_MH-750'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1050_MH-750_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1050_MH-800'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1050_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1050_MH-850'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1050_MH-850_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1050_MH-900'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1050_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1050_MH-950'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1050_MH-950_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1100_MH-1000'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1100_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1100_MH-330'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1100_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1100_MH-350'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1100_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1100_MH-400'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1100_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1100_MH-450'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1100_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1100_MH-500'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1100_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1100_MH-550'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1100_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1100_MH-600'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1100_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1100_MH-650'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1100_MH-650_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1100_MH-700'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1100_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1100_MH-750'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1100_MH-750_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1100_MH-800'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1100_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1100_MH-850'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1100_MH-850_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1100_MH-900'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1100_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1100_MH-950'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1100_MH-950_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1150_MH-1050'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1150_MH-1050_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1150_MH-330'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1150_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1150_MH-350'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1150_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1150_MH-450'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1150_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1150_MH-550'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1150_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1150_MH-650'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1150_MH-650_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1150_MH-750'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1150_MH-750_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1150_MH-850'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1150_MH-850_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1150_MH-950'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1150_MH-950_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1200_MH-1000'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1200_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1200_MH-1100'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1200_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1200_MH-330'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1200_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1200_MH-350'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1200_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1200_MH-400'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1200_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1200_MH-500'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1200_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1200_MH-600'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1200_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1200_MH-700'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1200_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1200_MH-800'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1200_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1200_MH-850'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1200_MH-850_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1200_MH-900'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1200_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1300_MH-1000'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1300_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1300_MH-1100'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1300_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1300_MH-1200'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1300_MH-1200_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1300_MH-350'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1300_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1300_MH-400'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1300_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1300_MH-500'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1300_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1300_MH-600'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1300_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1300_MH-700'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1300_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1300_MH-800'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1300_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1300_MH-900'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1300_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1400_MH-1000'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1400_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1400_MH-1100'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1400_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1400_MH-1200'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1400_MH-1200_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1400_MH-1300'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1400_MH-1300_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1400_MH-350'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1400_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1400_MH-400'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1400_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1400_MH-500'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1400_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1400_MH-600'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1400_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1400_MH-700'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1400_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1400_MH-800'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1400_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1400_MH-900'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1400_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1500_MH-1000'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1500_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1500_MH-1100'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1500_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1500_MH-1200'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1500_MH-1200_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1500_MH-1300'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1500_MH-1300_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1500_MH-1400'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1500_MH-1400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1500_MH-350'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1500_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1500_MH-400'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1500_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1500_MH-500'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1500_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1500_MH-600'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1500_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1500_MH-700'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1500_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1500_MH-800'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1500_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1500_MH-900'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1500_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1600_MH-1000'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1600_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1600_MH-1100'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1600_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1600_MH-1200'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1600_MH-1200_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1600_MH-1300'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1600_MH-1300_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1600_MH-1400'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1600_MH-1400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1600_MH-1500'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1600_MH-1500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1600_MH-350'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1600_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1600_MH-400'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1600_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1600_MH-500'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1600_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1600_MH-600'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1600_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1600_MH-700'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1600_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1600_MH-800'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1600_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1600_MH-900'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1600_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1700_MH-1000'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1700_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1700_MH-1100'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1700_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1700_MH-1200'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1700_MH-1200_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1700_MH-1300'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1700_MH-1300_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1700_MH-1400'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1700_MH-1400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1700_MH-1500'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1700_MH-1500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1700_MH-1600'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1700_MH-1600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1700_MH-350'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1700_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1700_MH-400'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1700_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1700_MH-500'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1700_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1700_MH-600'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1700_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1700_MH-700'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1700_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1700_MH-800'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1700_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1700_MH-900'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1700_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1800_MH-1000'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1800_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1800_MH-1100'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1800_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1800_MH-1200'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1800_MH-1200_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1800_MH-1300'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1800_MH-1300_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1800_MH-1400'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1800_MH-1400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1800_MH-1500'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1800_MH-1500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1800_MH-1600'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1800_MH-1600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1800_MH-1700'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1800_MH-1700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1800_MH-350'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1800_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1800_MH-400'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1800_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1800_MH-500'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1800_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1800_MH-600'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1800_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1800_MH-700'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1800_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1800_MH-800'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1800_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1800_MH-900'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1800_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1900_MH-1000'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1900_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1900_MH-1100'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1900_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1900_MH-1200'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1900_MH-1200_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1900_MH-1300'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1900_MH-1300_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1900_MH-1400'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1900_MH-1400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1900_MH-1500'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1900_MH-1500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1900_MH-1600'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1900_MH-1600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1900_MH-1700'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1900_MH-1700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1900_MH-1800'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1900_MH-1800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1900_MH-350'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1900_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1900_MH-400'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1900_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1900_MH-500'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1900_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1900_MH-600'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1900_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1900_MH-700'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1900_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1900_MH-800'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1900_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-1900_MH-900'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-1900_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-2000_MH-1000'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-2000_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-2000_MH-1100'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-2000_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-2000_MH-1200'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-2000_MH-1200_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-2000_MH-1300'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-2000_MH-1300_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-2000_MH-1400'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-2000_MH-1400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-2000_MH-1500'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-2000_MH-1500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-2000_MH-1600'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-2000_MH-1600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-2000_MH-1700'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-2000_MH-1700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-2000_MH-1800'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-2000_MH-1800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-2000_MH-1900'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-2000_MH-1900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-2000_MH-350'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-2000_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-2000_MH-400'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-2000_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-2000_MH-500'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-2000_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-2000_MH-600'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-2000_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-2000_MH-700'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-2000_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-2000_MH-800'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-2000_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-2000_MH-900'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-2000_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-2100_MH-1000'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-2100_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-2100_MH-1100'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-2100_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-2100_MH-1200'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-2100_MH-1200_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-2100_MH-1300'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-2100_MH-1300_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-2100_MH-1400'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-2100_MH-1400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-2100_MH-1500'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-2100_MH-1500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-2100_MH-1600'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-2100_MH-1600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-2100_MH-1700'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-2100_MH-1700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-2100_MH-1800'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-2100_MH-1800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-2100_MH-1900'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-2100_MH-1900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-2100_MH-2000'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-2100_MH-2000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-2100_MH-350'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-2100_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-2100_MH-400'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-2100_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-2100_MH-500'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-2100_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-2100_MH-600'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-2100_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-2100_MH-700'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-2100_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-2100_MH-800'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-2100_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-2100_MH-900'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-2100_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-430_MH-330'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-430_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-450_MH-330'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-450_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-450_MH-350'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-450_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-500_MH-330'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-500_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-500_MH-350'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-500_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-500_MH-370'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-500_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-500_MH-400'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-500_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-550_MH-330'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-550_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-550_MH-350'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-550_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-550_MH-400'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-550_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-550_MH-450'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-550_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-600_MH-330'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-600_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-600_MH-350'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-600_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-600_MH-400'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-600_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-600_MH-450'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-600_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-600_MH-500'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-600_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-650_MH-330'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-650_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-650_MH-350'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-650_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-650_MH-400'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-650_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-650_MH-450'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-650_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-650_MH-500'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-650_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-650_MH-550'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-650_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-700_MH-330'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-700_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-700_MH-350'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-700_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-700_MH-370'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-700_MH-370_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-700_MH-400'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-700_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-700_MH-450'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-700_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-700_MH-500'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-700_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-700_MH-550'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-700_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-700_MH-600'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-700_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-750_MH-330'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-750_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-750_MH-350'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-750_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-750_MH-400'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-750_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-750_MH-450'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-750_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-750_MH-500'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-750_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-750_MH-550'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-750_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-750_MH-600'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-750_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-750_MH-650'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-750_MH-650_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-800_MH-330'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-800_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-800_MH-350'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-800_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-800_MH-400'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-800_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-800_MH-450'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-800_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-800_MH-500'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-800_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-800_MH-550'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-800_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-800_MH-600'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-800_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-800_MH-650'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-800_MH-650_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-800_MH-700'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-800_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-850_MH-330'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-850_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-850_MH-350'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-850_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-850_MH-400'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-850_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-850_MH-450'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-850_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-850_MH-500'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-850_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-850_MH-550'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-850_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-850_MH-600'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-850_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-850_MH-650'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-850_MH-650_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-850_MH-700'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-850_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-850_MH-750'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-850_MH-750_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-900_MH-330'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-900_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-900_MH-350'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-900_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-900_MH-370'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-900_MH-370_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-900_MH-400'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-900_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-900_MH-450'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-900_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-900_MH-500'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-900_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-900_MH-550'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-900_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-900_MH-600'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-900_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-900_MH-650'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-900_MH-650_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-900_MH-700'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-900_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-900_MH-750'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-900_MH-750_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-900_MH-800'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-900_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-950_MH-330'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-950_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-950_MH-350'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-950_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-950_MH-400'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-950_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-950_MH-450'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-950_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-950_MH-500'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-950_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-950_MH-550'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-950_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-950_MH-600'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-950_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-950_MH-650'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-950_MH-650_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-950_MH-700'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-950_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-950_MH-750'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-950_MH-750_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-950_MH-800'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-950_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+Samples['AToZHToLLTTbar_MA-950_MH-850'] = {'nanoAOD' : '/AToZHToLLTTbar_MA-950_MH-850_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM'}
+## WW aTGCs ---------------------------------------------------------------------------##
+Samples['WWToLNuLNu_MWW-0To500'] = {'dasInst' : 'prod/phys03', 'nanoAOD' : '/WWToLNuLNu_MWW-0To500_TuneCP5_SMEFT_13TeV-madgraph-pythia8/phys_smp-NanoAODv9_UL2017_v2-00000000000000000000000000000000/USER' } 
+Samples['WWToLNuLNu_MWW-500To750'] = {'dasInst' : 'prod/phys03', 'nanoAOD' : '/WWToLNuLNu_MWW-500to750_TuneCP5_SMEFT_13TeV-madgraph-pythia8/phys_smp-NanoAODv9_UL2017_v2-00000000000000000000000000000000/USER'}
+Samples['WWToLNuLNu_MWW-750To1000'] = {'dasInst' : 'prod/phys03', 'nanoAOD' : '/WWToLNuLNu_MWW-750To1000_TuneCP5_SMEFT_13TeV-madgraph-pythia8/phys_smp-NanoAODv9_UL2017_v2-00000000000000000000000000000000/USER'}
+Samples['WWToLNuLNu_MWW-1000ToInf'] = {'dasInst' : 'prod/phys03', 'nanoAOD' : '/WWToLNuLNu_MWW-1000ToInf_TuneCP5_SMEFT_13TeV-madgraph-pythia8/phys_smp-NanoAODv9_UL2017_v2-00000000000000000000000000000000/USER' } 
+

--- a/mkShapesRDF/processor/framework/samples/samplesCrossSections_UL.py
+++ b/mkShapesRDF/processor/framework/samples/samplesCrossSections_UL.py
@@ -35,11 +35,660 @@
 # 	X	Unknown! - Cross section not yet there
 
 xs_db = {}
-xs_db["DYJetsToLL_M-50"] = ["xsec=6077.22", "kfact=1.000", "ref=E"]
-xs_db["EWKZ2Jets_ZToLL_M-50"] = ["xsec=6.215", "kfact=1.000", "ref=W"]
-xs_db["EWKZ2Jets_ZToLL_M-50_MJJ-120"] = ["xsec=1.723", "kfact=1.000", "ref=N"]
-xs_db["EWKZ2Jets_ZToLL_M-50_MJJ-120_herwig7_angular"] = [
-    "xsec=1.723",
-    "kfact=1.000",
-    "ref=N",
-]
+
+### W+jets
+xs_db['WJetsToLNu']                   	= ['xsec=61526.7',	'kfact=1.00',		'ref=E']
+xs_db['WJetsToLNu-LO']                	= ['xsec=61526.7',	'kfact=1.00',		'ref=E']
+xs_db['WJetsToLNu_Sherpa']                	= ['xsec=61526.7',	'kfact=1.00',		'ref=E']
+
+# XSDB: WJets-LO XS = 53870 pb
+# WJets-NNLO XS = 61526.7 pb
+# k-fact = 1.14
+xs_db['WJetsToLNu_HT70To100']                 = ['xsec=1264.0',        'kfact=1.14',           'ref=W']   
+xs_db['WJetsToLNu_HT100To200']          	= ['xsec=1256.00',	'kfact=1.14',		'ref=W']
+xs_db['WJetsToLNu_HT200To400']          	= ['xsec=335.500',	'kfact=1.14',		'ref=W']
+xs_db['WJetsToLNu_HT400To600']           	= ['xsec=45.2500',	'kfact=1.14',		'ref=W']
+xs_db['WJetsToLNu_HT600To800']          	= ['xsec=10.9700',	'kfact=1.14',		'ref=W']
+xs_db['WJetsToLNu_HT800To1200']         	= ['xsec=4.93300',	'kfact=1.14',		'ref=W']
+xs_db['WJetsToLNu_HT1200To2500']        	= ['xsec=1.16000',	'kfact=1.14',		'ref=W']
+xs_db['WJetsToLNu_HT2500ToInf']         	= ['xsec=0.02678',	'kfact=1.00',		'ref=I']
+
+xs_db['WJetsToLNu_Pt-100To250']               = ['xsec=763.7',	        'kfact=1.0',		'ref=W']  
+xs_db['WJetsToLNu_Pt-250To400']               = ['xsec=27.55', 	'kfact=1.0',		'ref=W']
+xs_db['WJetsToLNu_Pt-400To600']               = ['xsec=3.477', 	'kfact=1.0',		'ref=W']
+xs_db['WJetsToLNu_Pt-600ToInf']               = ['xsec=0.5415',	'kfact=1.0',		'ref=W']
+
+# Sum of XS: 53330 + 8875 + 3338 = 65543
+# NNLO XS = 61526.7
+# k factor = 61526.7 / 65543
+xs_db['WJetsToLNu_0J']                        = [ 'xsec=53330',        'kfact=0.94',           'ref=W' ]
+xs_db['WJetsToLNu_1J']                        = [ 'xsec=8875',         'kfact=0.94',           'ref=W' ]
+xs_db['WJetsToLNu_2J']                        = [ 'xsec=3338',         'kfact=0.94',           'ref=W' ]
+
+
+### DY
+xs_db['DYJetsToLL_M-10to50']          	= ['xsec=18610.0',	'kfact=1.000',		'ref=E']
+xs_db['DYJetsToLL_M-10to50-LO']               = ['xsec=18610.0',       'kfact=1.000',          'ref=E']
+xs_db['DYJetsToLL_M-10to50_NLO']              = ['xsec=20490.0',      'kfact=1.000',          'ref=W']
+
+xs_db['DYJetsToLL_M-50']                      = ['xsec=6077.22',       'kfact=1.000',          'ref=E']
+xs_db['DYJetsToLL_M-50-LO']      	        = ['xsec=6077.22',	'kfact=1.000',		'ref=E']
+xs_db['DYJetsToLL_M-50-LO_ext1']     	        = ['xsec=6077.22',	'kfact=1.000',		'ref=E']
+
+xs_db['DYJetsToTT_MuEle_M-50']                = ['xsec=250.997',       'kfact=1.000',          'ref=E']  # (6077.22/3)*(0.352)^2
+
+# DYJetsToLL_M-50 = 6077.22 --> 5129 + 951.5 + 361.4 = 6441.9 --> k-factor = 0.94
+xs_db['DYJetsToLL_0J']                        = [ 'xsec=5129',         'kfact=0.94',           'ref=W' ]
+xs_db['DYJetsToLL_1J']                        = [ 'xsec=951.5',        'kfact=0.94',           'ref=W' ]
+xs_db['DYJetsToLL_2J']                        = [ 'xsec=361.4',        'kfact=0.94',           'ref=W' ]
+
+xs_db['DYJetsToLL_M-50_HT-70to100']           = ['xsec=146.5',   	'kfact=1.23',	        'ref=W'] 
+xs_db['DYJetsToLL_M-50_HT-100to200']          = ['xsec=160.7',	        'kfact=1.23',	        'ref=W'] 
+xs_db['DYJetsToLL_M-50_HT-200to400']          = ['xsec=48.63',	        'kfact=1.23',	        'ref=W'] 
+xs_db['DYJetsToLL_M-50_HT-400to600']          = ['xsec=6.993',	        'kfact=1.23',	        'ref=W'] 
+xs_db['DYJetsToLL_M-50_HT-600to800']          = ['xsec=1.761',	        'kfact=1.23',	        'ref=W'] 
+xs_db['DYJetsToLL_M-50_HT-800to1200']         = ['xsec=0.8021',	'kfact=1.23',	        'ref=W'] 
+xs_db['DYJetsToLL_M-50_HT-1200to2500']        = ['xsec=0.1937',	'kfact=1.23',	        'ref=W'] 
+xs_db['DYJetsToLL_M-50_HT-2500toInf']         = ['xsec=0.003514',	'kfact=1.23',	        'ref=W'] 
+
+xs_db['DYJetsToLL_M-4to50_HT-100to200']       = ['xsec=204.',          'kfact=1.000',          'ref=W']
+xs_db['DYJetsToLL_M-4to50_HT-200to400']       = ['xsec=54.39',         'kfact=1.000',          'ref=W']
+xs_db['DYJetsToLL_M-4to50_HT-400to600']       = ['xsec=5.697',         'kfact=1.000',          'ref=W']
+xs_db['DYJetsToLL_M-4to50_HT-600toInf']       = ['xsec=1.85',          'kfact=1.000',          'ref=W']
+
+xs_db['EWKZ2Jets_ZToLL_M-50']                 = ['xsec=6.215',         'kfact=1.000',          'ref=W']
+
+### Wgamma
+xs_db['WGToLNuG']                             = ['xsec=412.7',         'kfact=1.000',          'ref=W']
+xs_db['Wg_AMCNLOFXFX_01J_PDF']                = ['xsec=191.8',         'kfact=1.000',          'ref=I']
+xs_db['Wg_AMCNLOFXFX_01J']                    = ['xsec=191.8',         'kfact=1.000',          'ref=I']
+ 
+### WW
+xs_db['WWTo2L2Nu']	                 	= ['xsec=12.178',	'kfact=1.000',		'ref=E']
+xs_db['WWTo2L2Nu_TuneCP5Up']                	= ['xsec=12.178',	'kfact=1.000',		'ref=E']		
+xs_db['WWTo2L2Nu_TuneCP5Down']               	= ['xsec=12.178',	'kfact=1.000',		'ref=E']		
+
+# 1.4*0.0368 --> 1.4 is a k-factor, 0.0368 comes from XSDB, divided by 1000
+xs_db['GluGluToWWToENEN']      	        = ['xsec=0.05152',	'kfact=1.000',		'ref=W']
+xs_db['GluGluToWWToENMN']              	= ['xsec=0.05152',	'kfact=1.000',		'ref=W']
+xs_db['GluGluToWWToENTN']              	= ['xsec=0.05152',	'kfact=1.000',		'ref=W']
+xs_db['GluGluToWWToMNEN']              	= ['xsec=0.05152',	'kfact=1.000',		'ref=W']
+xs_db['GluGluToWWToMNMN']              	= ['xsec=0.05152',	'kfact=1.000',		'ref=W']
+xs_db['GluGluToWWToMNTN']              	= ['xsec=0.05152',	'kfact=1.000',		'ref=W']
+xs_db['GluGluToWWToTNEN']              	= ['xsec=0.05152',	'kfact=1.000',		'ref=W']
+xs_db['GluGluToWWToTNMN']              	= ['xsec=0.05152',	'kfact=1.000',		'ref=W']
+xs_db['GluGluToWWToTNTN']              	= ['xsec=0.05152',	'kfact=1.000',		'ref=W']
+
+
+### WZ
+xs_db['WZ']			                = ['xsec=47.130',	'kfact=1.000',		'ref=E']
+
+xs_db['WZTo3LNu']		                = ['xsec=4.666',  	'kfact=1.000',		'ref=X'] # X = https://cms.cern.ch/iCMS/jsp/openfile.jsp?tp=draft&files=AN2019_156_v8.pdf
+xs_db['WZTo3LNu_mllmin4p0']	                = ['xsec=4.666',   	'kfact=1.000',		'ref=X'] # X = https://cms.cern.ch/iCMS/jsp/openfile.jsp?tp=draft&files=AN2019_156_v8.pdf BUT KEEPING INCLUSIVE VALUE!!! NEED TO CHECK!
+xs_db['WZTo3LNu_mllmin0p1']	                = ['xsec=4.666',   	'kfact=1.000',		'ref=X'] # X = https://cms.cern.ch/iCMS/jsp/openfile.jsp?tp=draft&files=AN2019_156_v8.pdf BUT KEEPING INCLUSIVE VALUE!!! NEED TO CHECK!
+xs_db['WZTo2Q2L_mllmin4p0']	                = ['xsec=5.5950',	'kfact=1.000',		'ref=E'] # KEEPING INCLUSIVE VALUE!!! NEED TO CHECK!
+xs_db['WZTo1L3Nu']                            = ['xsec=3.033',         'kfact=1.000',          'ref=E']
+
+xs_db['WZJJ_Inclusive']                       = ['xsec=0.01627',       'kfact=1.000',          'ref=W']
+xs_db['WZJJ_LL']                              = ['xsec=0.001375',      'kfact=1.000',          'ref=W']
+xs_db['WZJJ_TL']                              = ['xsec=0.003186',      'kfact=1.000',          'ref=W']
+xs_db['WZJJ_LT']                              = ['xsec=0.002824',      'kfact=1.000',          'ref=W']
+xs_db['WZJJ_TT']                              = ['xsec=0.008854',      'kfact=1.000',          'ref=W']
+
+xs_db['WZG']                                  = ['xsec=0.04345',       'kfact=1.000',          'ref=E']
+
+### ZZ
+xs_db['ZZ']                                   = ['xsec=16.52300', 	'kfact=1.000',		'ref=E']
+xs_db['ZZTo2Q2L']                             = ['xsec=2.33',  	'kfact=1.000',		'ref=E'] # 16.523 * (3*0.033658)*(0.69911)*2
+xs_db['ZZTo2Q2L_mllmin4p0']                   = ['xsec=2.33',  	'kfact=1.000',		'ref=E'] # KEEPING INCLUSIVE VALUE!!! NEED TO CHECK!
+xs_db['ZZTo2Nu2Q']                            = ['xsec=4.62',  	'kfact=1.000',		'ref=E'] # 16.52300 * (0.20)*(0.69911)*2
+xs_db['ZZTo4L']                               = ['xsec=1.325', 	'kfact=1.000',		'ref=E']
+xs_db['ZZTo4L_M-1toInf']                      = ['xsec=1.374', 	'kfact=1.000',		'ref=E'] # KEEPING INCLUSIVE VALUE!!! NEED TO CHECK!
+xs_db['ZZTo2L2Nu']                            = ['xsec=0.667', 	'kfact=1.000',		'ref=E'] # 16.52300 *(3*0.033658)*(0.20)*2
+xs_db['ZZTo2Q2Nu']                            = ['xsec=4.62',  	'kfact=1.000',		'ref=E'] # 16.52300 *(3*0.69911)*(0.20)*2
+xs_db['ZZTo4Q']                               = ['xsec=8.076', 	'kfact=1.000',		'ref=E'] # 16.52300*(0.69911)**2
+
+xs_db['ZZGTo4L']                              = ['xsec=0.02202',	'kfact=1.000',		'ref=W']
+
+### ZG
+xs_db['ZGToLLG']                              = ['xsec=51.1',          'kfact=1.000',          'ref=W']
+
+
+### Top
+xs_db['TTJets-LO']                            = ['xsec=831.76',	'kfact=1.000',		'ref=E']
+
+xs_db['TT_DiLept'] 	             	        = ['xsec=87.310',	'kfact=1.000',		'ref=E']
+
+xs_db['TTTo2L2Nu'] 	             	        = ['xsec=87.310',	'kfact=1.000',		'ref=E']
+xs_db['TTTo2L2Nu_TuneCP5Up']         	        = ['xsec=87.310',	'kfact=1.000',		'ref=E']
+xs_db['TTTo2L2Nu_TuneCP5Down']       	        = ['xsec=87.310',	'kfact=1.000',		'ref=E']
+xs_db['TTTo2L2Nu_hdampUp']         	        = ['xsec=87.310',	'kfact=1.000',		'ref=E']
+xs_db['TTTo2L2Nu_hdampDown']         	        = ['xsec=87.310',	'kfact=1.000',		'ref=E']
+
+xs_db['TTJets_DiLept']                        = ['xsec=87.310',        'kfact=1.000',          'ref=E']
+
+xs_db['TTToSemiLeptonic']                     = ['xsec=364.35',	'kfact=1.000',	        'ref=E']  # 831.76 * 0.6760 * 0.1080 * 3 * 2
+xs_db['TTToSemiLeptonic_TuneCP5Up']           = ['xsec=364.35',	'kfact=1.000',	        'ref=E']
+xs_db['TTToSemiLeptonic_TuneCP5Down']         = ['xsec=364.35',	'kfact=1.000',	        'ref=E']
+xs_db['TTToSemiLeptonic_hdampUp']             = ['xsec=364.35',	'kfact=1.000',	        'ref=E']
+xs_db['TTToSemiLeptonic_hdampDown']           = ['xsec=364.35',	'kfact=1.000',	        'ref=E']
+
+xs_db['ST_t-channel_top']                     = ['xsec=44.07048',	'kfact=1.000',		'ref=D']
+xs_db['ST_t-channel_top_TuneCP5Up']           = ['xsec=44.07048',	'kfact=1.000',		'ref=D']
+xs_db['ST_t-channel_top_TuneCP5Down']         = ['xsec=44.07048',	'kfact=1.000',		'ref=D']
+xs_db['ST_t-channel_top_hdampUp']             = ['xsec=44.07048',	'kfact=1.000',		'ref=D']
+xs_db['ST_t-channel_top_hdampDown']           = ['xsec=44.07048',	'kfact=1.000',		'ref=D']
+xs_db['ST_t-channel_top_5f']                  = ['xsec=136.02',        'kfact=1.000',          'ref=Z']
+
+xs_db['ST_t-channel_antitop']                 = ['xsec=26.2278',       'kfact=1.000',		'ref=D']
+xs_db['ST_t-channel_antitop_TuneCP5Up']       = ['xsec=26.2278',       'kfact=1.000',		'ref=D']
+xs_db['ST_t-channel_antitop_TuneCP5Down']     = ['xsec=26.2278',       'kfact=1.000',		'ref=D']
+xs_db['ST_t-channel_antitop_hdampUp']         = ['xsec=26.2278',       'kfact=1.000',		'ref=D']
+xs_db['ST_t-channel_antitop_hdampDown']       = ['xsec=26.2278',       'kfact=1.000',		'ref=D']
+xs_db['ST_t-channel_antitop_5f']              = ['xsec=80.95',         'kfact=1.000',		'ref=D']
+
+# What does noHad mean?
+# We want both of the Ws not to decay hadronically? --> 35.85 * (1 - 0.6741)^2
+xs_db['ST_tW_antitop']                        = ['xsec=35.85',		'kfact=1.000',		'ref=D']
+xs_db['ST_tW_antitop_noHad']                  = ['xsec=3.808',         'kfact=1.000',          'ref=D'] # 35.85 * (1 - 0.6741)^2 - previously XS = 1
+xs_db['ST_tW_antitop_noHad_TuneCP5Up']        = ['xsec=3.808',         'kfact=1.000',          'ref=D'] # 35.85 * (1 - 0.6741)^2 - previously XS = 1
+xs_db['ST_tW_antitop_noHad_TuneCP5Down']      = ['xsec=3.808',         'kfact=1.000',          'ref=D'] # 35.85 * (1 - 0.6741)^2 - previously XS = 1
+xs_db['ST_tW_antitop_noHad_hdampUp']          = ['xsec=3.808',         'kfact=1.000',          'ref=D'] # 35.85 * (1 - 0.6741)^2 - previously XS = 1
+xs_db['ST_tW_antitop_noHad_hdampDown']        = ['xsec=3.808',         'kfact=1.000',          'ref=D'] # 35.85 * (1 - 0.6741)^2 - previously XS = 1
+xs_db['ST_tW_antitop_noHad_PDF']              = ['xsec=3.808',         'kfact=1.000',          'ref=D'] # 35.85 * (1 - 0.6741)^2 - previously XS = 1
+
+xs_db['ST_tW_top']                            = ['xsec=35.85',		'kfact=1.000',		'ref=D']
+xs_db['ST_tW_top_noHad']                      = ['xsec=3.808',         'kfact=1.000',          'ref=D'] # 35.85 * (1 - 0.6741)^2 - previously XS = 1
+xs_db['ST_tW_top_noHad_TuneCP5Up']            = ['xsec=3.808',         'kfact=1.000',          'ref=D'] # 35.85 * (1 - 0.6741)^2 - previously XS = 1
+xs_db['ST_tW_top_noHad_TuneCP5Down']          = ['xsec=3.808',         'kfact=1.000',          'ref=D'] # 35.85 * (1 - 0.6741)^2 - previously XS = 1
+xs_db['ST_tW_top_noHad_hdampUp']              = ['xsec=3.808',         'kfact=1.000',          'ref=D'] # 35.85 * (1 - 0.6741)^2 - previously XS = 1
+xs_db['ST_tW_top_noHad_hdampDown']            = ['xsec=3.808',         'kfact=1.000',          'ref=D'] # 35.85 * (1 - 0.6741)^2 - previously XS = 1
+xs_db['ST_tW_top_noHad_PDF']                  = ['xsec=3.808',         'kfact=1.000',          'ref=D'] # 35.85 * (1 - 0.6741)^2 - previously XS = 1
+
+# All ST_s-channel xs_db are "leptonDecays" --> t->Wb->lvb
+xs_db['ST_s-channel']                         = ['xsec=3.34368',	'kfact=1.000',		'ref=D'] # 10.32 * (3*0.108) --> the W boson decays leptonically
+xs_db['ST_s-channel_TuneCP5Up']               = ['xsec=3.34368',	'kfact=1.000',		'ref=D'] # 10.32 * (3*0.108) --> the W boson decays leptonically
+xs_db['ST_s-channel_TuneCP5Down']             = ['xsec=3.34368',	'kfact=1.000',		'ref=D'] # 10.32 * (3*0.108) --> the W boson decays leptonically
+xs_db['ST_s-channel_TuneCP5CR1']              = ['xsec=3.34368',	'kfact=1.000',		'ref=D'] # 10.32 * (3*0.108) --> the W boson decays leptonically
+xs_db['ST_s-channel_TuneCP5CR2']              = ['xsec=3.34368',	'kfact=1.000',		'ref=D'] # 10.32 * (3*0.108) --> the W boson decays leptonically
+xs_db['ST_s-channel_erdON']                   = ['xsec=3.34368',	'kfact=1.000',		'ref=D'] # 10.32 * (3*0.108) --> the W boson decays leptonically
+xs_db['ST_s-channel_JMENano']                 = ['xsec=3.34368',	'kfact=1.000',		'ref=D'] # 10.32 * (3*0.108) --> the W boson decays leptonically
+# Exception: here, the W decays hadronically ("hadronicDecays") --> t->Wb->qq'b
+xs_db['ST_s-channel_had']                     = ['xsec=7.05062',	'kfact=1.000',		'ref=D'] # 10.32 * (0.6832)  --> the W boson decays hadronically
+
+xs_db['TTWJetsToQQ']                          = ['xsec=0.4377',        'kfact=1.000',          'ref=W']      
+xs_db['TTZToQQ']                              = ['xsec=0.5297',        'kfact=1.000',          'ref=E']
+xs_db['TTZToQQ_Dilept']                       = ['xsec=0.0568',        'kfact=1.000',          'ref=W']
+
+xs_db['TTWJetsToLNu']                         = ['xsec=0.2161',	'kfact=1.000',		'ref=E']	
+xs_db['TTWJetsToLNu_TuneCP5Up']               = ['xsec=0.2161',	'kfact=1.000',		'ref=E']	
+xs_db['TTWJetsToLNu_TuneCP5Down']             = ['xsec=0.2161',	'kfact=1.000',		'ref=E']	
+
+xs_db['TTZToLLNuNu_M-10']                     = ['xsec=0.2439',	'kfact=1.000',		'ref=W']
+xs_db['TTZToLLNuNu_M-10_TuneCP5Up']           = ['xsec=0.2439',	'kfact=1.000',		'ref=W']
+xs_db['TTZToLLNuNu_M-10_TuneCP5Down']         = ['xsec=0.2439',	'kfact=1.000',		'ref=W']
+
+xs_db['tZq_ll']   				= ['xsec=0.07580',	'kfact=1.000',	        'ref=E']
+xs_db['tZq_ll_TuneCP5Up']   			= ['xsec=0.07580',	'kfact=1.000',	        'ref=E']
+xs_db['tZq_ll_TuneCP5Down'] 			= ['xsec=0.07580',	'kfact=1.000',	        'ref=E']
+
+xs_db['tZq_ll_4f']                            = ['xsec=0.0761',        'kfact=1.000',          'ref=W']
+xs_db['tZq_ll_4f_TuneCP5Up']                  = ['xsec=0.0761',        'kfact=1.000',          'ref=W']
+xs_db['tZq_ll_4f_TuneCP5Down']                = ['xsec=0.0761',        'kfact=1.000',          'ref=W']
+
+
+## VVV
+xs_db['WWW']			        	= ['xsec=0.2158',	'kfact=1.000',		'ref=W']
+xs_db['WWW_ext1']			        = ['xsec=0.2158',	'kfact=1.000',		'ref=W']
+                                               
+xs_db['WWZ']				        = ['xsec=0.1707',	'kfact=1.000',		'ref=W']
+xs_db['WWZ_ext1']     			= ['xsec=0.1707',	'kfact=1.000',		'ref=W']
+                                               
+xs_db['WZZ']	 			        = ['xsec=0.05709',	'kfact=1.000',		'ref=W']
+xs_db['WZZ_ext1']			        = ['xsec=0.05709',	'kfact=1.000',		'ref=W']
+                                               
+xs_db['ZZZ']				        = ['xsec=0.01476',	'kfact=1.000',		'ref=W']
+xs_db['ZZZ_ext1']			        = ['xsec=0.01476',	'kfact=1.000',		'ref=W']
+                                               
+xs_db['WWG']                                  = ['xsec=0.2147',        'kfact=1.000',          'ref=E']
+
+xs_db['WWW_DiLeptonFilter']			= ['xsec=0.007205',	'kfact=1.000',		'ref=W']
+
+xs_db['WWZTo4L2Nu']				= ['xsec=0.001809',	'kfact=1.000',		'ref=W'] # 0.1707*(3*0.108)*(3*0.108)*(3*0.033658)
+
+
+### QCD
+xs_db['QCD_Pt_15to20_bcToE']    		= ['xsec=186200',	'kfact=1.000',  	'ref=I']
+xs_db['QCD_Pt_20to30_bcToE']    		= ['xsec=303800',	'kfact=1.000',  	'ref=I']
+xs_db['QCD_Pt_30to80_bcToE']    		= ['xsec=362300',	'kfact=1.000',  	'ref=I']
+xs_db['QCD_Pt_80to170_bcToE']    		= ['xsec=33700',		'kfact=1.000',  	'ref=I']
+xs_db['QCD_Pt_170to250_bcToE']    		= ['xsec=2125',		'kfact=1.000',  	'ref=I']
+xs_db['QCD_Pt_250toInf_bcToE']    		= ['xsec=562.5',		'kfact=1.000',  	'ref=I']
+
+xs_db['QCD_HT200to300']                       = ['xsec=1555000',       'kfact=1.000',          'ref=W']
+xs_db['QCD_HT300to500']                       = ['xsec=324500' ,       'kfact=1.000',          'ref=W']
+xs_db['QCD_HT500to700']                       = ['xsec=30310'  ,       'kfact=1.000',          'ref=W']
+xs_db['QCD_HT700to1000']                      = ['xsec=6444'   ,       'kfact=1.000',          'ref=W']
+xs_db['QCD_HT1000to1500']                     = ['xsec=1127'   ,       'kfact=1.000',          'ref=W']
+xs_db['QCD_HT1500to2000']                     = ['xsec=109.8'  ,       'kfact=1.000',          'ref=W']
+xs_db['QCD_HT2000toInf']                      = ['xsec=21.98'  ,       'kfact=1.000',          'ref=W']
+
+xs_db['QCD_Pt_15to30']                        = ['xsec=1244000000',    'kfact=1.000',          'ref=W']
+xs_db['QCD_Pt_30to50']                        = ['xsec=106500000',     'kfact=1.000',          'ref=W']
+
+
+### Signals - XS are dummy and taken from YR4 N3LO
+
+# https://twiki.cern.ch/twiki/bin/view/LHCPhysics/CERNYellowReportPageBR
+# BR (H-->WW) = 0.2152
+# BR (H-->tt) = 0.06256
+# BR (H-->ZZ) = 0.02641
+
+# ggH - XS = 48.52 pb
+# 58.52*0.2152*(3*0.108)*(3*0.108)
+xs_db['GluGluHToWWTo2L2Nu_M125']    		= ['xsec=1.32200',	'kfact=1.000',	'ref=F']
+xs_db['GluGluHToWWTo2L2Nu_M125_TuneCP5Up']    = ['xsec=1.32200',       'kfact=1.000',  'ref=F']
+xs_db['GluGluHToWWTo2L2Nu_M125_TuneCP5Down']  = ['xsec=1.32200',       'kfact=1.000',  'ref=F']
+xs_db['GluGluHToWWTo2L2Nu_M125_Powheg']       = ['xsec=1.32200',       'kfact=1.000',  'ref=F']
+xs_db['GluGluHToWWTo2L2Nu_M125_noPDF']        = ['xsec=1.32200',       'kfact=1.000',  'ref=F']
+xs_db['GluGluHToWWTo2L2Nu_M125_Pohweg_noPDF'] = ['xsec=1.32200',       'kfact=1.000',  'ref=F']
+
+xs_db['GGHjjToWWTo2L2Nu_minloHJJ_M125']       = ['xsec=1',             'kfact=1.000',  'ref=X'] 
+
+# 48.52*0.06256
+xs_db['GluGluHToTauTau_M125']    		= ['xsec=3.0354',	'kfact=1.000',	'ref=F']
+xs_db['GluGluHToTauTau_M125_Powheg'] 		= ['xsec=3.0354',	'kfact=1.000',	'ref=F']
+xs_db['GluGluHToTauTau_M125_FXFX'] 		= ['xsec=3.0354',	'kfact=1.000',	'ref=F']
+
+# 48.52*0.02641*(3*0.033658)*(3*0.033658)
+xs_db['GluGluHToZZTo4L_M125']    		= ['xsec=0.01306',	'kfact=1.000',	'ref=F']
+xs_db['GluGluHToZZTo4L_M125_TuneCP5Up']       = ['xsec=0.01306',       'kfact=1.000',  'ref=F']
+xs_db['GluGluHToZZTo4L_M125_TuneCP5Down']     = ['xsec=0.01306',       'kfact=1.000',  'ref=F']
+
+# VBF - XS = 3.779 pb
+# 3.779*0.2152*(3*0.108)*(3*0.108) 
+xs_db['VBFHToWWTo2L2Nu_M125']    		= ['xsec=0.08537',	'kfact=1.000',	'ref=F']
+xs_db['VBFHToWWTo2L2Nu_M125_TuneCP5Up']       = ['xsec=0.08537',       'kfact=1.000',  'ref=F'] 
+xs_db['VBFHToWWTo2L2Nu_M125_TuneCP5Down']     = ['xsec=0.08537',       'kfact=1.000',  'ref=F']
+xs_db['VBFHToWWTo2L2Nu_M125_noPDF']           = ['xsec=0.08537',       'kfact=1.000',  'ref=F']   
+
+# 3.779*0.06256
+xs_db['VBFHToTauTau_M125']    		= ['xsec=0.236',  	'kfact=1.000',	'ref=F']
+
+# WH - XS(W+H) = 0.8380 pb and XS(W-H) = 0.5313 pb
+# 0.5313*0.2152
+xs_db['HWminusJ_HToWW_M125']    		= ['xsec=0.114',  	'kfact=1.000',	'ref=F']
+# 0.05967*0.2152*(3*0.108)*(3*0.108) 
+xs_db['HWminusJ_HToWWTo2L2Nu_WToLNu_M125']    = ['xsec=0.001348',      'kfact=1.000',  'ref=F'] 
+
+# 0.8380*0.2152
+xs_db['HWplusJ_HToWW_M125']                   = ['xsec=0.1803',        'kfact=1.000',  'ref=F']
+# 0.09404*0.2152*(3*0.108)*(3*0.108) 
+xs_db['HWplusJ_HToWWTo2L2Nu_WToLNu_M125']     = ['xsec=0.002124',      'kfact=1.000',  'ref=F']  
+
+# ZH -  XS = 0.8824 pb 
+# XS(ggZH) = 0.1227 pb
+# XS(HZJ)  = 0.8824 - 0.1227 = 0.7597 pb
+# 0.7597*0.2152
+xs_db['HZJ_HToWW_M125']    	        	= ['xsec=0.1635',	'kfact=1.000',	'ref=F']
+# 0.7597*0.2152*(3*0.033658)*(3*0.108)*(3*0.108)
+xs_db['HZJ_HToWWTo2L2Nu_ZTo2L_M125']    	= ['xsec=0.0017329',	'kfact=1.000',	'ref=F']
+
+# 0.1227*0.2152
+xs_db['ggZH_HToWW_M125']        		= ['xsec=0.0264',	'kfact=1.000',	'ref=F']
+# 0.1227*0.2152*(3*0.033658)*(3*0.108)*(3*0.108)
+xs_db['ggZH_HToWWTo2L2Nu_ZTo2L_M125']         = ['xsec=0.000279889',   'kfact=1.000',  'ref=F']
+
+xs_db['GluGluHToZZTo4L_MiNLOHJJ_M125']            = ['xsec=1',         'kfact=1.000',  'ref=X']
+xs_db['GluGluHToZZTo4L_MiNLOHJJ_M125_TuneCP5Up']  = ['xsec=1',         'kfact=1.000',  'ref=X']
+xs_db['GluGluHToZZTo4L_MiNLOHJJ_M125_TuneCP5Down']= ['xsec=1',         'kfact=1.000',  'ref=X']
+
+# ttH - XS = 0.5065
+# 0.5065*(1-0.5809)
+xs_db['ttHToNonbb_M125']       		= ['xsec=0.2123',	'kfact=1.000',	'ref=F']
+
+
+# Additional Higgs signals with non-SM parameters 
+# All XS set to 1. I haven't even looked at them
+xs_db['H0PM_ToWWTo2L2Nu']                     = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['H0PH_ToWWTo2L2Nu']                     = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['H0PHf05_ToWWTo2L2Nu']                  = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['H0M_ToWWTo2L2Nu']                      = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['H0Mf05_ToWWTo2L2Nu']                   = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['H0L1_ToWWTo2L2Nu']                     = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['H0L1f05_ToWWTo2L2Nu']                  = ['xsec=1',             'kfact=1.000',  'ref=X']
+
+xs_db['VBF_H0PM_ToWWTo2L2Nu']                 = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['VBF_H0PH_ToWWTo2L2Nu']                 = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['VBF_H0PHf05_ToWWTo2L2Nu']              = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['VBF_H0M_ToWWTo2L2Nu']                  = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['VBF_H0Mf05_ToWWTo2L2Nu']               = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['VBF_H0L1_ToWWTo2L2Nu']                 = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['VBF_H0L1Zgf05_ToWWTo2L2Nu']            = ['xsec=1',             'kfact=1.000',  'ref=X']
+
+xs_db['WH_H0PM_ToWWTo2L2Nu']                  = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['WH_H0PH_ToWWTo2L2Nu']                  = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['WH_H0PHf05_ToWWTo2L2Nu']               = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['WH_H0M_ToWWTo2L2Nu']                   = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['WH_H0Mf05_ToWWTo2L2Nu']                = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['WH_H0L1_ToWWTo2L2Nu']                  = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['WH_H0L1f05_ToWWTo2L2Nu']               = ['xsec=1',             'kfact=1.000',  'ref=X']
+
+xs_db['ZH_H0PM_ToWWTo2L2Nu']                  = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['ZH_H0PH_ToWWTo2L2Nu']                  = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['ZH_H0PHf05_ToWWTo2L2Nu']               = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['ZH_H0M_ToWWTo2L2Nu']                   = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['ZH_H0Mf05_ToWWTo2L2Nu']                = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['ZH_H0L1_ToWWTo2L2Nu']                  = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['ZH_H0L1f05_ToWWTo2L2Nu']               = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['ZH_H0LZgf05_ToWWTo2L2Nu']              = ['xsec=1',             'kfact=1.000',  'ref=X']
+
+xs_db['GGHjj_H0PM_ToWWTo2L2Nu']               = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['GGHjj_H0M_ToWWTo2L2Nu']                = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['GGHjj_H0Mf05_ToWWTo2L2Nu']             = ['xsec=1',             'kfact=1.000',  'ref=X']
+
+xs_db['ttH_H0PM_ToWWTo2L2Nu']                 = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['ttH_H0M_ToWWTo2L2Nu']                  = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['ttH_H0Mf05_ToWWTo2L2Nu']               = ['xsec=1',             'kfact=1.000',  'ref=X']        
+
+xs_db['SSWW']                                 = ['xsec=1',             'kfact=1.000',  'ref=W']
+
+xs_db['VBS_SSWW_cW_INT']                      = ['xsec=1',             'kfact=1.000',  'ref=W']
+xs_db['VBS_SSWW_cW_BSM']                      = ['xsec=1',             'kfact=1.000',  'ref=W']
+xs_db['VBS_SSWW_cHW_INT']                     = ['xsec=1',             'kfact=1.000',  'ref=W']
+xs_db['VBS_SSWW_cHW_BSM']                     = ['xsec=1',             'kfact=1.000',  'ref=W']
+xs_db['VBS_SSWW_cW_cHW']                      = ['xsec=1',             'kfact=1.000',  'ref=W']
+
+xs_db['WpWmJJ_EWK_noTop_pol_LL']              = ['xsec=0.01132',             'kfact=1.000',  'ref=I']
+xs_db['WpWmJJ_EWK_noTop_pol_LT']              = ['xsec=0.01446',             'kfact=1.000',  'ref=I']
+xs_db['WpWmJJ_EWK_noTop_pol_TL']              = ['xsec=0.01512',             'kfact=1.000',  'ref=I']
+xs_db['WpWmJJ_EWK_noTop_pol_TT']              = ['xsec=0.05026',             'kfact=1.000',  'ref=I']
+
+xs_db['WpWmJJ_EWK_noTop_CMWW_pol_LL']         = ['xsec=0.01394',             'kfact=1.000',  'ref=I']
+xs_db['WpWmJJ_EWK_noTop_CMWW_pol_LT']         = ['xsec=0.01318',             'kfact=1.000',  'ref=I']
+xs_db['WpWmJJ_EWK_noTop_CMWW_pol_TL']         = ['xsec=0.01390',             'kfact=1.000',  'ref=I']
+xs_db['WpWmJJ_EWK_noTop_CMWW_pol_TT']         = ['xsec=0.05004',             'kfact=1.000',  'ref=I']
+
+xs_db['WpWmJJ_EWK_noTop']                     = ['xsec=0.09283',             'kfact=1.000',  'ref=I']
+xs_db['WpWmJJ_QCD_noTop']                     = ['xsec=2.190',               'kfact=1.000',  'ref=I']
+xs_db['WpWmJJ_EWK_QCD_noTop']                 = ['xsec=2.295',               'kfact=1.000',  'ref=I']
+
+xs_db['AToZHToLLTTbar_MA-1000_MH-330'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1000_MH-350'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1000_MH-400'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1000_MH-450'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1000_MH-500'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1000_MH-550'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1000_MH-600'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1000_MH-650'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1000_MH-700'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1000_MH-750'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1000_MH-800'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1000_MH-850'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1000_MH-900'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1050_MH-330'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1050_MH-350'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1050_MH-400'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1050_MH-450'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1050_MH-500'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1050_MH-550'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1050_MH-600'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1050_MH-700'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1050_MH-750'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1050_MH-800'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1050_MH-850'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1050_MH-900'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1050_MH-950'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1100_MH-1000'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1100_MH-330'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1100_MH-350'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1100_MH-400'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1100_MH-450'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1100_MH-500'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1100_MH-550'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1100_MH-600'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1100_MH-650'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1100_MH-700'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1100_MH-750'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1100_MH-800'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1100_MH-850'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1100_MH-900'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1100_MH-950'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1150_MH-1050'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1150_MH-330'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1150_MH-350'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1150_MH-450'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1150_MH-550'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1150_MH-650'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1150_MH-750'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1150_MH-850'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1150_MH-950'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1200_MH-1000'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1200_MH-1100'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1200_MH-330'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1200_MH-350'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1200_MH-400'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1200_MH-500'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1200_MH-600'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1200_MH-700'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1200_MH-800'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1200_MH-850'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1200_MH-900'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1300_MH-1000'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1300_MH-1100'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1300_MH-1200'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1300_MH-350'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1300_MH-400'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1300_MH-500'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1300_MH-600'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1300_MH-700'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1300_MH-800'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1300_MH-900'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1400_MH-1000'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1400_MH-1100'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1400_MH-1200'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1400_MH-1300'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1400_MH-350'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1400_MH-400'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1400_MH-500'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1400_MH-600'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1400_MH-700'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1400_MH-800'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1400_MH-900'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1500_MH-1000'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1500_MH-1100'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1500_MH-1200'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1500_MH-1300'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1500_MH-1400'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1500_MH-350'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1500_MH-400'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1500_MH-500'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1500_MH-600'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1500_MH-700'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1500_MH-800'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1500_MH-900'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1600_MH-1000'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1600_MH-1100'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1600_MH-1200'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1600_MH-1300'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1600_MH-1400'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1600_MH-1500'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1600_MH-350'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1600_MH-400'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1600_MH-500'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1600_MH-600'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1600_MH-700'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1600_MH-800'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1600_MH-900'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1700_MH-1000'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1700_MH-1100'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1700_MH-1200'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1700_MH-1300'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1700_MH-1400'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1700_MH-1500'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1700_MH-1600'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1700_MH-350'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1700_MH-400'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1700_MH-500'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1700_MH-600'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1700_MH-700'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1700_MH-800'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1700_MH-900'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1800_MH-1000'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1800_MH-1100'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1800_MH-1200'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1800_MH-1300'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1800_MH-1400'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1800_MH-1500'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1800_MH-1600'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1800_MH-1700'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1800_MH-350'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1800_MH-400'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1800_MH-500'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1800_MH-600'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1800_MH-700'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1800_MH-800'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1800_MH-900'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1900_MH-1000'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1900_MH-1100'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1900_MH-1200'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1900_MH-1300'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1900_MH-1400'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1900_MH-1500'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1900_MH-1600'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1900_MH-1700'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1900_MH-1800'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1900_MH-350'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1900_MH-400'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1900_MH-500'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1900_MH-600'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1900_MH-700'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1900_MH-800'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-1900_MH-900'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-2000_MH-1000'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-2000_MH-1100'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-2000_MH-1200'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-2000_MH-1300'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-2000_MH-1400'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-2000_MH-1500'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-2000_MH-1600'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-2000_MH-1700'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-2000_MH-1800'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-2000_MH-1900'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-2000_MH-350'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-2000_MH-400'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-2000_MH-500'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-2000_MH-600'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-2000_MH-700'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-2000_MH-800'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-2000_MH-900'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-2100_MH-1000'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-2100_MH-1100'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-2100_MH-1200'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-2100_MH-1300'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-2100_MH-1400'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-2100_MH-1500'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-2100_MH-1600'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-2100_MH-1700'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-2100_MH-1800'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-2100_MH-1900'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-2100_MH-2000'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-2100_MH-350'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-2100_MH-400'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-2100_MH-500'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-2100_MH-600'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-2100_MH-700'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-2100_MH-800'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-2100_MH-900'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-430_MH-330'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-450_MH-330'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-450_MH-350'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-500_MH-330'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-500_MH-350'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-500_MH-370'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-500_MH-400'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-550_MH-330'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-550_MH-350'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-550_MH-400'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-550_MH-450'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-600_MH-330'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-600_MH-350'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-600_MH-400'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-600_MH-450'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-600_MH-500'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-650_MH-330'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-650_MH-350'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-650_MH-400'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-650_MH-450'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-650_MH-500'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-650_MH-550'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-700_MH-330'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-700_MH-350'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-700_MH-370'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-700_MH-400'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-700_MH-450'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-700_MH-500'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-700_MH-550'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-700_MH-600'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-750_MH-330'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-750_MH-350'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-750_MH-400'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-750_MH-450'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-750_MH-500'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-750_MH-550'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-750_MH-600'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-750_MH-650'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-800_MH-330'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-800_MH-350'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-800_MH-400'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-800_MH-450'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-800_MH-500'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-800_MH-550'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-800_MH-600'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-800_MH-650'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-800_MH-700'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-850_MH-330'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-850_MH-350'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-850_MH-400'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-850_MH-450'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-850_MH-500'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-850_MH-550'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-850_MH-600'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-850_MH-650'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-850_MH-700'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-850_MH-750'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-900_MH-330'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-900_MH-350'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-900_MH-370'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-900_MH-400'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-900_MH-450'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-900_MH-500'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-900_MH-550'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-900_MH-600'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-900_MH-650'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-900_MH-700'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-900_MH-750'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-900_MH-800'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-950_MH-330'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-950_MH-350'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-950_MH-400'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-950_MH-450'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-950_MH-500'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-950_MH-550'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-950_MH-600'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-950_MH-650'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-950_MH-700'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-950_MH-750'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-950_MH-800'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+xs_db['AToZHToLLTTbar_MA-950_MH-850'] = ['xsec=1',             'kfact=1.000',  'ref=X']
+
+# WW aTGCs
+xs_db['WWToLNuLNu_MWW-0To500']         = ['xsec=4.1880002',             'kfact=1.000',  'ref=X']
+xs_db['WWToLNuLNu_MWW-500To750']         = ['xsec=0.2617599',             'kfact=1.000',  'ref=X']
+xs_db['WWToLNuLNu_MWW-750To1000']         = ['xsec=0.0928599',             'kfact=1.000',  'ref=X']
+xs_db['WWToLNuLNu_MWW-1000ToInf']         = ['xsec=0.1599200',             'kfact=1.000',  'ref=X']
+
+# Added since NanoGardener?
+xs_db["EWKZ2Jets_ZToLL_M-50_MJJ-120"]                 = ["xsec=1.723", "kfact=1.000", "ref=N"]
+xs_db["EWKZ2Jets_ZToLL_M-50_MJJ-120_herwig7_angular"] = ["xsec=1.723", "kfact=1.000", "ref=N"]
+


### PR DESCRIPTION
PR to include the changes to mkShapesRDF I made before running the 2017 JES variations. 

The following changes were relevant to the JES variations:
- Changed JEC from Summer19UL17_V6_MC to Summer19UL17_V5_MC in Steps_cfg.py
- Updated the list of samples / cross sections in Run2017_UL2017_nAODv9.py, Summer20UL17_106x_nAODv9.py, and samplesCrossSections_UL.py 

The following were not directly used in the 2017 JES variations, but were added for completeness:
- 2017 lepton IDs in LeptonSel_cfg.py
- Trigger formulations / MET filter in formulasToAdd_MC_Full2017v9.py