### PR TITLE
[SHAPE] 2D histogram support, new hadd, support nuisances of type weight_rms and weight_envelope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ mkShapesRDF/processor/data/jsonpog*
 start.sh
 *build*
 *html*
+utils/bin*

--- a/install.sh
+++ b/install.sh
@@ -11,11 +11,25 @@ python -m pip install -e .[docs,dev]
 
 python -m pip install --no-binary=correctionlib correctionlib
 
+
+cd utils
+mkdir -p bin
+
+cd src && c++ hadd.cxx -o hadd2 $(root-config --cflags --libs) && cd .. && mv src/hadd2 bin/hadd2
+
+if [ $? -ne 0 ]; then
+      echo "Failed compiling hadd"
+      exit 1
+fi
+cd ..
+
 cat << EOF > start.sh
 #!/bin/bash
 $sourceCommand
 source `pwd`/myenv/bin/activate
 export STARTPATH=`pwd`/start.sh
+export PYTHONPATH=`pwd`/myenv/lib64/python3.9/site-packages:\$PYTHONPATH
+export PATH=`pwd`/utils/bin:\$PATH
 EOF
 
 chmod +x start.sh

--- a/install.sh
+++ b/install.sh
@@ -15,10 +15,10 @@ cat << EOF > start.sh
 #!/bin/bash
 $sourceCommand
 source `pwd`/myenv/bin/activate
+export STARTPATH=`pwd`/start.sh
 EOF
 
 chmod +x start.sh
-
 
 wget https://gpizzati.web.cern.ch/mkShapesRDF/jsonpog-integration.tar.gz
 tar -xzvf jsonpog-integration.tar.gz

--- a/mkShapesRDF/shapeAnalysis/BatchSubmission.py
+++ b/mkShapesRDF/shapeAnalysis/BatchSubmission.py
@@ -111,9 +111,9 @@ class BatchSubmission:
         for sample in self.samples:
             self.createBatch(sample)
 
-    def submit(self, dryRun=0, queue='workday'):
+    def submit(self, dryRun=0, queue="workday"):
         txtsh = ""
-        with open(os.environ['STARTPATH']) as file:
+        with open(os.environ["STARTPATH"]) as file:
             txtsh += file.read()
 
         mE = self.d.get("mountEOS", [])

--- a/mkShapesRDF/shapeAnalysis/latinos/LatinosUtils.py
+++ b/mkShapesRDF/shapeAnalysis/latinos/LatinosUtils.py
@@ -38,7 +38,7 @@ def flatten_cuts(cuts):
 
 def update_variables_with_categories(variables, categoriesmap):
     # variables can have "cuts" specifications
-    for variable in variables.items():
+    for variable in variables.values():
         if "cuts" not in variable:
             continue
 
@@ -60,7 +60,7 @@ def update_variables_with_categories(variables, categoriesmap):
 
 
 def update_nuisances_with_subsamples(nuisances, subsamplesmap):
-    for nuisance in nuisances.items():
+    for nuisance in nuisances.values():
         if "samples" not in nuisance:
             continue
 

--- a/mkShapesRDF/shapeAnalysis/mkShapesRDF.py
+++ b/mkShapesRDF/shapeAnalysis/mkShapesRDF.py
@@ -21,6 +21,7 @@ ROOT.gROOT.SetBatch(True)
 
 headersPath = os.path.dirname(os.path.dirname(__file__)) + "/include/headers.hh"
 ROOT.gInterpreter.Declare(f'#include "{headersPath}"')
+from mkShapesRDF.shapeAnalysis.utils import hist2array
 
 
 def defaultParser():
@@ -105,7 +106,14 @@ def defaultParser():
     parser.add_argument(
         "-q",
         "--queue",
-        choices=['espresso', 'microcentury', 'longlunch', 'workday', 'tomorrow', 'testmatch'],
+        choices=[
+            "espresso",
+            "microcentury",
+            "longlunch",
+            "workday",
+            "tomorrow",
+            "testmatch",
+        ],
         help="Condor queue",
         required=False,
         default="workday",
@@ -264,7 +272,6 @@ def main():
 
         errsD = list(map(lambda k: "/".join(k.split("/")[:-1]), errs))
         filesD = list(map(lambda k: "/".join(k.split("/")[:-1]), files))
-        # print(files)
         notFinished = list(set(filesD).difference(set(errsD)))
         print(notFinished)
         tabulated = []
@@ -273,7 +280,6 @@ def main():
         import tabulate
 
         print(tabulate.tabulate(tabulated))
-        # print('queue 1 Folder in ' + ' '.join(list(map(lambda k: k.split('/')[-1], notFinished))))
         normalErrs = """Warning in <TClass::Init>: no dictionary for class edm::ProcessHistory is available
         Warning in <TClass::Init>: no dictionary for class edm::ProcessConfiguration is available
         Warning in <TClass::Init>: no dictionary for class edm::ParameterSetBlob is available
@@ -293,6 +299,9 @@ def main():
         TClass::Init:0: RuntimeWarning: no dictionary for class edm::ProcessHistory is available
         TClass::Init:0: RuntimeWarning: no dictionary for class edm::ProcessConfiguration is available
         TClass::Init:0: RuntimeWarning: no dictionary for class pair<edm::Hash<1>,edm::ParameterSetBlob> is available         
+        cling::DynamicLibraryManager::loadLibrary(): libGLU.so.1: cannot open shared object file: No such file or directory
+        Error in <TNetXNGFile::Close>:
+        Warning in <TChain::AddFile>: Adding tree with no entries from file
         """
         normalErrs = normalErrs.split("\n")
         normalErrs = list(map(lambda k: k.strip(" ").strip("\t"), normalErrs))
@@ -333,7 +342,9 @@ def main():
             if resubmit == 1:
                 from mkShapesRDF.shapeAnalysis.BatchSubmission import BatchSubmission
 
-                BatchSubmission.resubmitJobs(batchFolder, tag, toResubmit, dryRun, queue)
+                BatchSubmission.resubmitJobs(
+                    batchFolder, tag, toResubmit, dryRun, queue
+                )
 
         if resubmit == 2:
             # resubmit all the jobs that are not finished
@@ -366,14 +377,115 @@ def main():
         print("\n\n", filesToMerge, "\n\n")
 
         print(f"Hadding files into {folder}/{outputFolder}/{outputFile}")
-        for fileToMerge in filesToMerge:
-          os.system(f'echo {fileToMerge} >> filesToMerge_{outputFile}.txt')
+        with open(f"filesToMerge_{outputFile}.txt", "w") as file:
+            file.write("\n".join(filesToMerge))
         process = subprocess.Popen(
-            f'hadd -j 10 {folder}/{outputFolder}/{outputFile} @filesToMerge_{outputFile}.txt; \
-            rm filesToMerge_{outputFile}.txt',
+            f"hadd2 -j 10 {folder}/{outputFolder}/{outputFile} @filesToMerge_{outputFile}.txt; \
+            rm filesToMerge_{outputFile}.txt",
             shell=True,
         )
         process.wait()
+        if process.returncode == 0:
+            print("Hadd was successful")
+            import mkShapesRDF.shapeAnalysis.latinos.LatinosUtils as utils
+
+            f = ROOT.TFile.Open(f"{outputFolder}/{outputFile}", "update")
+            # post process -> nuisance envelops and RMS
+            cuts = cuts["cuts"]
+            categoriesmap = utils.flatten_cuts(cuts)
+            subsamplesmap = utils.flatten_samples(samples)
+            utils.update_variables_with_categories(variables, categoriesmap)
+            utils.update_nuisances_with_subsamples(nuisances, subsamplesmap)
+            utils.update_nuisances_with_categories(nuisances, categoriesmap)
+            for nuisance in nuisances.keys():
+                if not (
+                    nuisances[nuisance].get("kind", "").endswith("envelope")
+                    or nuisances[nuisance].get("kind", "").endswith("rms")
+                ):
+                    continue
+                print("Work for ", nuisance)
+                _cuts = list(cuts.keys())
+                _samples = list(samples.keys())
+                for cut in _cuts:
+                    for variable in variables.keys():
+                        f.cd(f"/{cut}/{variable}")
+                        print("work in ", cut, variable)
+                        histos = [k.GetName() for k in ROOT.gDirectory.GetListOfKeys()]
+                        for sampleName in _samples:
+                            limitSamples = nuisances[nuisance].get("samples", {})
+                            if not (
+                                len(limitSamples) == 0
+                                or sampleName in limitSamples.keys()
+                            ):
+                                # print(f'{sampleName} does not have nuisance {nuisance}')
+                                continue
+                            histosNameToProcess = list(
+                                filter(
+                                    lambda k: k.startswith(
+                                        f"histo_{sampleName}_{nuisances[nuisance]['name']}_SPECIAL_NUIS"
+                                    ),
+                                    histos,
+                                )
+                            )
+                            histosToProcess = list(
+                                map(
+                                    lambda k: ROOT.gDirectory.Get(k).Clone(),
+                                    histosNameToProcess,
+                                )
+                            )
+                            if len(histosToProcess) == 0:
+                                print(
+                                    f'No variations found for {sampleName} in {cut}/{variable} for nuisance {nuisances[nuisance]["name"]}',
+                                    file=sys.stderr,
+                                )
+                                continue
+
+                                sys.exit(1)
+                            hNominal = ROOT.gDirectory.Get(
+                                f"histo_{sampleName}"
+                            ).Clone()
+
+                            hName = f"histo_{sampleName}_{nuisances[nuisance]['name']}"
+                            h_up = histosToProcess[0].Clone()
+                            h_do = histosToProcess[0].Clone()
+                            variations = np.empty(
+                                (
+                                    len(histosToProcess),
+                                    histosToProcess[0].GetNbinsX() + 2,
+                                ),
+                                dtype=float,
+                            )
+                            for i in range(len(histosToProcess)):
+                                variations[i, :] = hist2array(
+                                    histosToProcess[i], flow=True
+                                )
+                            arrup = 0
+                            arrdo = 0
+                            if nuisances[nuisance]["kind"].endswith("envelope"):
+                                arrup = np.max(variations, axis=0)
+                                arrdo = np.min(variations, axis=0)
+                            elif nuisances[nuisance]["kind"].endswith("rms"):
+                                vnominal = hist2array(hNominal, flow=True)
+                                arrnom = np.tile(vnominal, (variations.shape[0], 1))
+                                arrv = np.sqrt(
+                                    np.mean(np.square(variations - arrnom), axis=0)
+                                )
+                                arrup = vnominal + arrv
+                                arrdo = vnominal - arrv
+                            else:
+                                continue
+
+                            for i in range(0, h_up.GetNbinsX() + 2):
+                                h_up.SetBinContent(i, arrup[i])
+                                h_do.SetBinContent(i, arrdo[i])
+                            print(hName)
+                            h_up.SetName(hName + "Up")
+                            h_up.Write()
+                            h_do.SetName(hName + "Down")
+                            h_do.Write()
+                            for histo in histosNameToProcess:
+                                ROOT.gDirectory.Delete(f"{histo};*")
+            f.Close()
 
     else:
         print("Operating mode was set to -1, nothing was done")

--- a/mkShapesRDF/shapeAnalysis/runner.py
+++ b/mkShapesRDF/shapeAnalysis/runner.py
@@ -3,9 +3,21 @@ import sys
 import ROOT
 from array import array
 from mkShapesRDF.lib.parse_cpp import ParseCpp
+import os
+from math import sqrt
+from fnmatch import fnmatch
 
 ROOT.gROOT.SetBatch(True)
 ROOT.TH1.SetDefaultSumw2(True)
+
+
+def _fold(_h, _to, _from):
+    sumw2 = _h.GetSumw2()
+
+    _h.SetBinContent(_to, _h.GetBinContent(_to) + _h.GetBinContent(_from))
+    sumw2[_to] = sumw2[_to] + sumw2[_from]
+    _h.SetBinContent(_from, 0.0)
+    sumw2[_from] = 0.0
 
 
 class RunAnalysis:
@@ -121,6 +133,11 @@ class RunAnalysis:
             map(lambda k: nuisance["folderDown"] + "/" + k, _files)
         )
         nuisanceFilesUp = list(map(lambda k: nuisance["folderUp"] + "/" + k, _files))
+        for nuisFile in nuisanceFilesUp + nuisanceFilesDown:
+            # print(nuisFile)
+            if not os.path.exists(nuisFile):
+                print("File", nuisFile, "does not exist", file=sys.stderr)
+                sys.exit(1)
         return [nuisanceFilesDown, nuisanceFilesUp]
 
     @staticmethod
@@ -252,11 +269,14 @@ class RunAnalysis:
                     continue
                 if nuisance.get("type", "") == "shape":
                     if nuisance.get("kind", "") == "suffix":
-                        if nuisance["folderUp"] in usedFolders:
-                            continue
-                        usedFolders.append(nuisance["folderUp"])
+                        if nuisance.get("folderUp", "") != "":
+                            if nuisance["folderUp"] in usedFolders:
+                                continue
+                            usedFolders.append(nuisance["folderUp"])
 
-                        friendsFiles += RunAnalysis.getNuisanceFiles(nuisance, files)
+                            friendsFiles += RunAnalysis.getNuisanceFiles(
+                                nuisance, files
+                            )
 
             tnom = RunAnalysis.getTTreeNomAndFriends(files, friendsFiles)
 
@@ -264,7 +284,7 @@ class RunAnalysis:
                 df = ROOT.RDataFrame(tnom)
                 df = df.Range(limit)
             else:
-                #ROOT.EnableImplicitMT()
+                # ROOT.EnableImplicitMT()
                 df = ROOT.RDataFrame(tnom)
             if sampleName not in self.dfs.keys():
                 self.dfs[sample[0]] = {}
@@ -437,6 +457,7 @@ class RunAnalysis:
                     if nuisance.get("type", "") == "shape":
                         if nuisance.get("kind", "") == "suffix":
                             variation = nuisance["mapDown"]
+                            separator = nuisance.get("separator", "_")
                             variedCols = list(
                                 filter(lambda k: k.endswith(variation), columnNames)
                             )
@@ -447,8 +468,10 @@ class RunAnalysis:
                                 map(
                                     lambda k: k[
                                         RunAnalysis.index_sub(k, "Events.")
-                                        + len("Events.") : -len("_" + variation)
-                                    ],
+                                        + len("Events.") : -len(separator + variation)
+                                    ]
+                                    if "Events" in k
+                                    else k[: -len(separator + variation)],
                                     variedCols,
                                 )
                             )
@@ -458,25 +481,34 @@ class RunAnalysis:
                                     not in self.dfs[sampleName][index]["usedVariables"]
                                 ):
                                     # baseCol is never used -> useless to register variation
+                                    print("unused variable", baseCol)
                                     continue
+
+                                if not (
+                                    baseCol in [str(k) for k in df.GetColumnNames()]
+                                ):
+                                    continue
+
                                 if "bool" not in str(df.GetColumnType(baseCol)).lower():
                                     varNameDown = (
                                         baseCol
-                                        + "_"
+                                        + separator
                                         + nuisance["mapDown"]
                                         + "*"
                                         + nuisance["samples"][sampleName][1]
                                     )
                                     varNameUp = (
                                         baseCol
-                                        + "_"
+                                        + separator
                                         + nuisance["mapUp"]
                                         + "*"
                                         + nuisance["samples"][sampleName][0]
                                     )
                                 else:
-                                    varNameDown = baseCol + "_" + nuisance["mapDown"]
-                                    varNameUp = baseCol + "_" + nuisance["mapUp"]
+                                    varNameDown = (
+                                        baseCol + separator + nuisance["mapDown"]
+                                    )
+                                    varNameUp = baseCol + separator + nuisance["mapUp"]
 
                                 _type = df.GetColumnType(baseCol)
                                 expr = (
@@ -492,7 +524,15 @@ class RunAnalysis:
                                     variationName=nuisance["name"],
                                 )
 
-                        elif nuisance.get("kind", "") == "weight":
+                        elif (
+                            sum(
+                                [
+                                    fnmatch(nuisance.get("kind", ""), k)
+                                    for k in ["weight", "*_rms", "*_envelope"]
+                                ]
+                            )
+                            > 0
+                        ):
                             continue
                         else:
                             print("Unsupported nuisance")
@@ -560,11 +600,96 @@ class RunAnalysis:
                                     variationTags=["Down", "Up"],
                                     variationName=nuisance["name"],
                                 )
-                        elif nuisance.get("kind", "") == "suffix":
+                        elif (
+                            sum(
+                                [
+                                    fnmatch(nuisance.get("kind", ""), k)
+                                    for k in ["suffix", "*_rms", "*_envelope"]
+                                ]
+                            )
+                            > 0
+                        ):
                             continue
                         else:
                             print("Unsupported nuisance")
                             sys.exit()
+                self.dfs[sampleName][index]["df"] = df
+
+    def loadSystematicsReweightsEnvelopeRMS(self):
+        """
+        Loads systematics of type ``weight_envelope`` or type ``weight_rms`` in the dataframes.
+        """
+        for sampleName in self.dfs.keys():
+            for index in self.dfs[sampleName].keys():
+                df = self.dfs[sampleName][index]["df"]
+                columnNames = self.dfs[sampleName][index]["columnNames"]
+                nuisances = self.nuisances
+                # nuisance key is not used
+                for _, nuisance in list(nuisances.items()):
+                    if sampleName not in nuisance.get("samples", {sampleName: []}):
+                        continue
+                    if nuisance.get("type", "") == "shape":
+                        if (
+                            nuisance.get("kind", "") == "weight_envelope"
+                            or nuisance.get("kind", "") == "weight_rms"
+                        ):
+                            weights = nuisance["samples"].get(sampleName, None)
+                            if weights is not None:
+                                variedNames = []
+                                variedTags = []
+                                for i, weight in enumerate(weights):
+                                    if weight not in columnNames:
+                                        nuisName = f'{nuisance["name"]}_{i}'
+                                        df = df.Define(nuisName, weight)
+                                        variedNames.append(nuisName)
+                                        variedTags.append(str(i))
+                                    else:
+                                        variedNames.append(weight)
+                                        variedTags.append(str(i))
+
+                                if df.GetColumnType("weight") == "double":
+                                    expr = (
+                                        "ROOT::RVecD"
+                                        + "{ "
+                                        + ", ".join(
+                                            [
+                                                f"weight * (double) {variedName}"
+                                                for variedName in variedNames
+                                            ]
+                                        )
+                                        + "}"
+                                    )
+                                elif df.GetColumnType("weight") == "float":
+                                    expr = (
+                                        "ROOT::RVecF"
+                                        + "{ "
+                                        + ", ".join(
+                                            [
+                                                f"weight * (float) {variedName}"
+                                                for variedName in variedNames
+                                            ]
+                                        )
+                                        + "}"
+                                    )
+                                else:
+                                    print(
+                                        "Weight column has unknown type:",
+                                        df.GetColumnType("weight"),
+                                        "while varied is: ",
+                                        df.GetColumnType(variedNames[0]),
+                                    )
+                                    sys.exit()
+
+                                df = df.Vary(
+                                    "weight",
+                                    expr,
+                                    variationTags=variedTags,
+                                    variationName=nuisance["name"]
+                                    + "_SPECIAL_NUIS_"
+                                    + nuisance["kind"].split("_")[-1],
+                                )
+                        else:
+                            continue
                 self.dfs[sampleName][index]["df"] = df
 
     def loadVariables(self):
@@ -866,19 +991,110 @@ class RunAnalysis:
                             _h = 0
                             _h = _s_var[_variation]
                             fold = variables[var].get("fold", 0)
-                            if fold == 1 or fold == 3:
-                                _h.SetBinContent(
-                                    1, _h.GetBinContent(0) + _h.GetBinContent(1)
+
+                            if isinstance(_h, ROOT.TH1D):
+                                if fold == 1 or fold == 3:
+                                    _from = 0
+                                    _to = 1
+                                    _fold(_h, _to, _from)
+
+                                if fold == 2 or fold == 3:
+                                    lastBin = _h.GetNbinsX()
+                                    _from = lastBin + 1
+                                    _to = lastBin
+                                    _fold(_h, _to, _from)
+
+                            elif isinstance(_h, ROOT.TH2D):
+                                nx = _h.GetNbinsX()
+                                ny = _h.GetNbinsY()
+
+                                if fold == 1 or fold == 3:
+                                    for i in range(0, ny + 2):
+                                        _from = 0
+                                        _to = 0
+                                        if i == 0:
+                                            _from = _h.GetBin(0, i)
+                                            _to = _h.GetBin(1, i + 1)
+                                        elif i == ny + 1:
+                                            _from = _h.GetBin(0, i)
+                                            _to = _h.GetBin(1, i - 1)
+                                        else:
+                                            _from = _h.GetBin(0, i)
+                                            _to = _h.GetBin(1, i)
+                                        _fold(_h, _to, _from)
+
+                                    for i in range(0, nx + 2):
+                                        _from = 0
+                                        _to = 0
+                                        if i == 0:
+                                            _from = _h.GetBin(i, 0)
+                                            _to = _h.GetBin(i + 1, 1)
+                                        elif i == ny + 1:
+                                            _from = _h.GetBin(i, 0)
+                                            _to = _h.GetBin(i - 1, 1)
+                                        else:
+                                            _from = _h.GetBin(i, 0)
+                                            _to = _h.GetBin(i, 1)
+                                        _fold(_h, _to, _from)
+
+                                if fold == 2 or fold == 3:
+                                    for i in range(0, ny + 2):
+                                        _from = 0
+                                        _to = 0
+                                        if i == 0:
+                                            _from = _h.GetBin(nx + 1, i)
+                                            _to = _h.GetBin(nx, i + 1)
+                                        elif i == ny + 1:
+                                            _from = _h.GetBin(nx + 1, i)
+                                            _to = _h.GetBin(nx, i - 1)
+                                        else:
+                                            _from = _h.GetBin(nx + 1, i)
+                                            _to = _h.GetBin(nx, i)
+                                        _fold(_h, _to, _from)
+
+                                    for i in range(0, nx + 2):
+                                        _from = 0
+                                        _to = 0
+                                        if i == 0:
+                                            _from = _h.GetBin(i, nx + 1)
+                                            _to = _h.GetBin(i + 1, nx)
+                                        elif i == ny + 1:
+                                            _from = _h.GetBin(i, nx + 1)
+                                            _to = _h.GetBin(i - 1, nx)
+                                        else:
+                                            _from = _h.GetBin(i, nx + 1)
+                                            _to = _h.GetBin(i, nx)
+                                        _fold(_h, _to, _from)
+
+                                # unroll 2d
+                                _name = _h.GetName()
+                                _h.SetName(_name + "_old")
+                                new_name = (
+                                    _name
+                                    + "_"
+                                    + _h_name
+                                    + "_"
+                                    + sampleName
+                                    + "_"
+                                    + str(index)
                                 )
-                                _h.SetBinContent(0, 0)
-                            if fold == 2 or fold == 3:
-                                lastBin = _h.GetNbinsX()
-                                _h.SetBinContent(
-                                    lastBin,
-                                    _h.GetBinContent(lastBin)
-                                    + _h.GetBinContent(lastBin + 1),
+
+                                _h2 = ROOT.TH1D(
+                                    new_name, _h.GetName(), nx * ny, 1, nx * ny
                                 )
-                                _h.SetBinContent(lastBin + 1, 0)
+                                for i in range(1, nx + 1):
+                                    for j in range(1, ny + 1):
+                                        new_ind = (i - 1) * ny + j
+                                        old_ind = _h.GetBin(i, j)
+                                        _h2.SetBinContent(
+                                            new_ind, _h.GetBinContent(old_ind)
+                                        )
+                                        _h2.SetBinError(
+                                            new_ind, _h.GetBinError(old_ind)
+                                        )
+                                del _h
+                                _h = _h2
+
                             _histos[_h_name] = _h.Clone()
                             # del _h
                         # del self.results[cut][var][sampleName]['object']
@@ -983,11 +1199,13 @@ class RunAnalysis:
 
                     for hname in mergedHistos.keys():
                         if hname == "nominal":
-                            mergedHistos[hname].SetName("histo_" + sampleName)
+                            _string = "histo_" + sampleName
+                            mergedHistos[hname].SetName(_string)
+                            mergedHistos[hname].SetTitle(_string)
                         else:
-                            mergedHistos[hname].SetName(
-                                "histo_" + sampleName + "_" + hname
-                            )
+                            _string = "histo_" + sampleName + "_" + hname
+                            mergedHistos[hname].SetName(_string)
+                            mergedHistos[hname].SetTitle(_string)
                         mergedHistos[hname].Write()
         f.Close()
 
@@ -1098,6 +1316,7 @@ class RunAnalysis:
         # load alias weight needed before nuisances of type weight
         self.loadAliasWeight()
         self.loadSystematicsReweights()
+        self.loadSystematicsReweightsEnvelopeRMS()
 
         # load all aliases remaining
         self.loadAliases(True)

--- a/mkShapesRDF/shapeAnalysis/runner.py
+++ b/mkShapesRDF/shapeAnalysis/runner.py
@@ -264,7 +264,7 @@ class RunAnalysis:
                 df = ROOT.RDataFrame(tnom)
                 df = df.Range(limit)
             else:
-                ROOT.EnableImplicitMT()
+                #ROOT.EnableImplicitMT()
                 df = ROOT.RDataFrame(tnom)
             if sampleName not in self.dfs.keys():
                 self.dfs[sample[0]] = {}

--- a/mkShapesRDF/shapeAnalysis/utils.py
+++ b/mkShapesRDF/shapeAnalysis/utils.py
@@ -1,0 +1,32 @@
+import numpy as np
+
+
+def hist2array(h, flow=False, copy=True, include_sumw2=False):
+    nx = h.GetNbinsX() + 2
+    dtype = 0
+    if isinstance(h, ROOT.TH1D):
+        dtype = np.double
+    elif isinstance(h, ROOT.TH1F):
+        dtype = np.float
+    elif isinstance(h, ROOT.TH1I):
+        dtype = np.int
+    else:
+        print("Histogram of type", h, "is not supperted", file=sys.stderr)
+        sys.exit(1)
+
+    vals = np.ndarray((nx,), dtype=dtype, buffer=h.GetArray())
+    sumw2 = np.ndarray((nx,), dtype=dtype, buffer=h.GetSumw2().GetArray())
+
+    shift = 0
+    if flow:
+        shift = 1
+    vals = vals[shift : nx - shift]
+    sum2 = sumw2[shift : nx - shift]
+
+    if copy:
+        vals = vals.copy()
+        sumw2 = sumw2.copy()
+    if include_sumw2:
+        return vals, sumw2
+    else:
+        return vals

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,4 +12,4 @@ line-length = 88
 target-version = ['py39']
 # include = 'examples\/*\/.*\.py$|mkShapesRDF.*\.py$|tests\/.+\.py$'
 include = 'mkShapesRDF.*\.py$|tests\/.+\.py$'
-force-exclude = 'mkShapesRDF/processor/data.*\.py$|mkShapesRDF/processor/condor.*\.py$'
+force-exclude = 'mkShapesRDF/processor/data.*\.py$|mkShapesRDF/processor/condor.*\.py$|utils*$'

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,7 @@ exclude =
     docs*
     logs*
     myenv*
+    utils*
 
 
 [flake8]
@@ -67,5 +68,5 @@ per-file-ignores =
     mkShapesRDF/shapeAnalysis/latinos/mkDatacards.py:E722,W605
     examples/*/*.py:E266
     mkShapesRDF/processor/framework*.py:E266,E262
-exclude = **/condor,docs,myenv,examples/*,mkShapesRDF.*,mkShapesRDF/processor/data*,mkShapesRDF/processor/condor*
+exclude = **/condor,docs,myenv,examples/*,mkShapesRDF.*,mkShapesRDF/processor/data*,mkShapesRDF/processor/condor*,utils*
 

--- a/utils/src/hadd.cxx
+++ b/utils/src/hadd.cxx
@@ -1,0 +1,569 @@
+/**
+  \file hadd.cxx
+  \brief This program will add histograms (see note) and Trees from a list of root files and write them to a target root file.
+  The target file is newly created and must not be
+  identical to one of the source files.
+
+  Syntax:
+  ```{.cpp}
+       hadd targetfile source1 source2 ...
+  ```
+  or
+  ```{.cpp}
+       hadd -f targetfile source1 source2 ...
+  ```
+  (targetfile is overwritten if it exists)
+
+  \param -a   Append to the output
+  \param -f   Force overwriting of output file.
+  \param -f[0-9] Set target compression level. 0 = uncompressed, 6 = highly compressed.
+  \param -fk  Sets the target file to contain the baskets with the same compression
+              as the input files (unless -O is specified). Compresses the meta data
+              using the compression level specified in the first input or the
+              compression setting after fk (for example 206 when using -fk206)
+  \param -ff  The compression level used is the one specified in the first input
+
+  \param -k   Skip corrupt or non-existent files, do not exit
+  \param -O   Re-optimize basket size when merging TTree
+  \param -v   Explicitly set the verbosity level: 0 request no output, 99 is the default
+  \param -j   Parallelise the execution in multiple processes
+  \param -dbg  Parallelise the execution in multiple processes in debug mode (Does not delete  partial  files  stored
+              inside working directory)
+  \param -d   Carry out the partial multiprocess execution in the specified directory
+  \param -n   Open at most `n` at once (use 0 to request to use the system maximum)
+  \param -experimental-io-features `<feature>` Enables the corresponding experimental feature for output trees
+  \return hadd returns a status code: 0 if OK, -1 otherwise
+
+  When the -f option is specified, one can also specify the compression
+  level of the target file. By default the compression level is 1 (kDefaultZLIB), but
+  if "-f0" is specified, the target file will not be compressed.
+  if "-f6" is specified, the compression level 6 will be used.
+
+  For example assume 3 files f1, f2, f3 containing histograms hn and Trees Tn
+   - f1 with h1 h2 h3 T1
+   - f2 with h1 h4 T1 T2
+   - f3 with h5
+  the result of
+  ```
+    hadd -f x.root f1.root f2.root f3.root
+  ```
+  will be a file x.root with h1 h2 h3 h4 h5 T1 T2
+  where
+   - h1 will be the sum of the 2 histograms in f1 and f2
+   - T1 will be the merge of the Trees in f1 and f2
+
+  The files may contain sub-directories.
+
+  If the source files contains histograms and Trees, one can skip
+  the Trees with
+  ```
+       hadd -T targetfile source1 source2 ...
+  ```
+
+  Wildcarding and indirect files are also supported
+  ```
+      hadd result.root  myfil*.root
+  ```
+  will merge all files in myfil*.root
+  ```
+      hadd result.root file1.root @list.txt file2. root myfil*.root
+  ```
+  will merge file1.root, file2.root, all files in myfil*.root
+  and all files in the indirect text file list.txt ("@" as the first
+  character of the file indicates an indirect file. An indirect file
+  is a text file containing a list of other files, including other
+  indirect files, one line per file).
+
+  If the sources and and target compression levels are identical (default),
+  the program uses the TChain::Merge function with option "fast", ie
+  the merge will be done without  unzipping or unstreaming the baskets
+  (i.e. direct copy of the raw byte on disk). The "fast" mode is typically
+  5 times faster than the mode unzipping and unstreaming the baskets.
+
+  If the option -cachesize is used, hadd will resize (or disable if 0) the
+  prefetching cache use to speed up I/O operations.
+
+  For options that take a size as argument, a decimal number of bytes is expected.
+  If the number ends with a `k`, `m`, `g`, etc., the number is multiplied
+  by 1000 (1K), 1000000 (1MB), 1000000000 (1G), etc.
+  If this prefix is followed by `i`, the number is multiplied by the traditional
+  1024 (1KiB), 1048576 (1MiB), 1073741824 (1GiB), etc.
+  The prefix can be optionally followed by B whose casing is ignored,
+  eg. 1k, 1K, 1Kb and 1KB are the same.
+
+  \note By default histograms are added. However hadd does not support the case where
+         histograms have their bit TH1::kIsAverage set.
+
+  \authors Rene Brun, Dirk Geppert, Sven A. Schmidt, Toby Burnett
+*/
+#include "Compression.h"
+#include <ROOT/RConfig.hxx>
+#include "ROOT/TIOFeatures.hxx"
+#include "TFile.h"
+#include "THashList.h"
+#include "TKey.h"
+#include "TClass.h"
+#include "TSystem.h"
+#include "TUUID.h"
+#include "ROOT/StringConv.hxx"
+#include "snprintf.h"
+
+#include <string>
+#include <iostream>
+#include <fstream>
+#include <cstdlib>
+#include <climits>
+#include <sstream>
+// #include "haddCommandLineOptionsHelp.h"
+
+#include "TFileMerger.h"
+#ifndef R__WIN32
+#include "ROOT/TProcessExecutor.hxx"
+#endif
+
+////////////////////////////////////////////////////////////////////////////////
+
+int main( int argc, char **argv )
+{
+   if ( argc < 3 || "-h" == std::string(argv[1]) || "--help" == std::string(argv[1]) ) {
+         // fprintf(stderr, kCommandLineOptionsHelp);
+         return 1;
+   }
+
+   ROOT::TIOFeatures features;
+   Bool_t append = kFALSE;
+   Bool_t force = kFALSE;
+   Bool_t skip_errors = kFALSE;
+   Bool_t reoptimize = kFALSE;
+   Bool_t noTrees = kFALSE;
+   Bool_t keepCompressionAsIs = kFALSE;
+   Bool_t useFirstInputCompression = kFALSE;
+   Bool_t multiproc = kFALSE;
+   Bool_t debug = kFALSE;
+   Int_t maxopenedfiles = 0;
+   Int_t verbosity = 99;
+   TString cacheSize;
+   SysInfo_t s;
+   gSystem->GetSysInfo(&s);
+   auto nProcesses = s.fCpus;
+   auto workingDir = gSystem->TempDirectory();
+   int outputPlace = 0;
+   int ffirst = 2;
+   Int_t newcomp = -1;
+   for( int a = 1; a < argc; ++a ) {
+      if ( strcmp(argv[a],"-T") == 0 ) {
+         noTrees = kTRUE;
+         ++ffirst;
+      } else if ( strcmp(argv[a],"-a") == 0 ) {
+         append = kTRUE;
+         ++ffirst;
+      } else if ( strcmp(argv[a],"-f") == 0 ) {
+         force = kTRUE;
+         ++ffirst;
+      } else if ( strcmp(argv[a],"-k") == 0 ) {
+         skip_errors = kTRUE;
+         ++ffirst;
+      } else if ( strcmp(argv[a],"-O") == 0 ) {
+         reoptimize = kTRUE;
+         ++ffirst;
+      } else if (strcmp(argv[a], "-dbg") == 0) {
+         debug = kTRUE;
+         verbosity = kTRUE;
+         ++ffirst;
+      } else if (strcmp(argv[a], "-d") == 0) {
+         if (a + 1 != argc && argv[a + 1][0] != '-') {
+            if (gSystem->AccessPathName(argv[a + 1])) {
+               std::cerr << "Error: could not access the directory specified: " << argv[a + 1]
+                         << ". We will use the system's temporal directory.\n";
+            } else {
+               workingDir = argv[a + 1];
+            }
+            ++a;
+            ++ffirst;
+         } else {
+            std::cout << "-d: no directory specified.  We will use the system's temporal directory.\n";
+         }
+         ++ffirst;
+      } else if (strcmp(argv[a], "-j") == 0) {
+         // If the number of processes is not specified, use the default.
+         if (a + 1 != argc && argv[a + 1][0] != '-') {
+            // number of processes specified
+            Long_t request = 1;
+            for (char *c = argv[a + 1]; *c != '\0'; ++c) {
+               if (!isdigit(*c)) {
+                  // Wrong number of Processes. Use the default:
+                  std::cerr << "Error: could not parse the number of processes to run in parallel passed after -j: "
+                            << argv[a + 1] << ". We will use the system maximum.\n";
+                  request = 0;
+                  break;
+               }
+            }
+            if (request == 1) {
+               request = strtol(argv[a + 1], 0, 10);
+               if (request < kMaxLong && request >= 0) {
+                  nProcesses = (Int_t)request;
+                  ++a;
+                  ++ffirst;
+                  std::cout << "Parallelizing  with " << nProcesses << " processes.\n";
+               } else {
+                  std::cerr << "Error: could not parse the number of processes to use passed after -j: " << argv[a + 1]
+                            << ". We will use the default value (number of logical cores).\n";
+               }
+            }
+         }
+         multiproc = kTRUE;
+         ++ffirst;
+      } else if ( strcmp(argv[a],"-cachesize=") == 0 ) {
+         int size;
+         static const size_t arglen = strlen("-cachesize=");
+         auto parseResult = ROOT::FromHumanReadableSize(argv[a]+arglen,size);
+         if (parseResult == ROOT::EFromHumanReadableSize::kParseFail) {
+            std::cerr << "Error: could not parse the cache size passed after -cachesize: "
+                      << argv[a + 1] << ". We will use the default value.\n";
+         } else if (parseResult == ROOT::EFromHumanReadableSize::kOverflow) {
+            double m;
+            const char *munit = nullptr;
+            ROOT::ToHumanReadableSize(INT_MAX,false,&m,&munit);
+            std::cerr << "Error: the cache size passed after -cachesize is too large: "
+                      << argv[a + 1] << " is greater than " << m << munit
+                      << ". We will use the default value.\n";
+         } else {
+            cacheSize = "cachesize=";
+            cacheSize.Append(argv[a]+1);
+         }
+         ++ffirst;
+      } else if ( strcmp(argv[a],"-cachesize") == 0 ) {
+         if (a+1 >= argc) {
+            std::cerr << "Error: no cache size number was provided after -cachesize.\n";
+         } else {
+            int size;
+            auto parseResult = ROOT::FromHumanReadableSize(argv[a+1],size);
+            if (parseResult == ROOT::EFromHumanReadableSize::kParseFail) {
+               std::cerr << "Error: could not parse the cache size passed after -cachesize: "
+                         << argv[a + 1] << ". We will use the default value.\n";
+            } else if (parseResult == ROOT::EFromHumanReadableSize::kOverflow) {
+               double m;
+               const char *munit = nullptr;
+               ROOT::ToHumanReadableSize(INT_MAX,false,&m,&munit);
+               std::cerr << "Error: the cache size passed after -cachesize is too large: "
+                         << argv[a + 1] << " is greater than " << m << munit
+                         << ". We will use the default value.\n";
+               ++a;
+               ++ffirst;
+            } else {
+               cacheSize = "cachesize=";
+               cacheSize.Append(argv[a+1]);
+               ++a;
+               ++ffirst;
+            }
+         }
+         ++ffirst;
+      } else if (!strcmp(argv[a], "-experimental-io-features")) {
+         if (a+1 >= argc) {
+            std::cerr << "Error: no IO feature was specified after -experimental-io-features; ignoring\n";
+         } else {
+            std::stringstream ss;
+            ss.str(argv[++a]);
+            ++ffirst;
+            std::string item;
+            while (std::getline(ss, item, ',')) {
+               if (!features.Set(item)) {
+                  std::cerr << "Ignoring unknown feature request: " << item << std::endl;
+               }
+            }
+         }
+         ++ffirst;
+      } else if ( strcmp(argv[a],"-n") == 0 ) {
+         if (a+1 >= argc) {
+            std::cerr << "Error: no maximum number of opened was provided after -n.\n";
+         } else {
+            Long_t request = strtol(argv[a+1], 0, 10);
+            if (request < kMaxLong && request >= 0) {
+               maxopenedfiles = (Int_t)request;
+               ++a;
+               ++ffirst;
+            } else {
+               std::cerr << "Error: could not parse the max number of opened file passed after -n: " << argv[a+1] << ". We will use the system maximum.\n";
+            }
+         }
+         ++ffirst;
+      } else if ( strcmp(argv[a],"-v") == 0 ) {
+         if (a+1 == argc || argv[a+1][0] == '-') {
+            // Verbosity level was not specified use the default:
+            verbosity = 99;
+//         if (a+1 >= argc) {
+//            std::cerr << "Error: no verbosity level was provided after -v.\n";
+         } else {
+            Bool_t hasFollowupNumber = kTRUE;
+            for (char *c = argv[a+1]; *c != '\0'; ++c) {
+               if (!isdigit(*c)) {
+                  // Verbosity level was not specified use the default:
+                  hasFollowupNumber = kFALSE;
+                  break;
+               }
+            }
+            if (hasFollowupNumber) {
+               Long_t request = strtol(argv[a+1], 0, 10);
+               if (request < kMaxLong && request >= 0) {
+                  verbosity = (Int_t)request;
+                  ++a;
+                  ++ffirst;
+               } else {
+                  verbosity = 99;
+                  std::cerr << "Error: could not parse the verbosity level passed after -v: " << argv[a+1] << ". We will use the default value (99).\n";
+               }
+            }
+         }
+         ++ffirst;
+      } else if ( argv[a][0] == '-' ) {
+         bool farg = false;
+         if (force && argv[a][1] == 'f') {
+            // Bad argument
+            std::cerr << "Error: Using option " << argv[a] << " more than once is not supported.\n";
+            ++ffirst;
+            farg = true;
+         }
+         const char *prefix = "";
+         if (argv[a][1] == 'f' && argv[a][2] == 'k') {
+            farg = true;
+            force = kTRUE;
+            keepCompressionAsIs = kTRUE;
+            prefix = "k";
+         }
+         if (argv[a][1] == 'f' && argv[a][2] == 'f') {
+            farg = true;
+            force = kTRUE;
+            useFirstInputCompression = kTRUE;
+            if (argv[a][3] != '\0') {
+               std::cerr << "Error: option -ff should not have any suffix: " << argv[a] << " (suffix has been ignored)\n";
+            }
+         }
+         char ft[7];
+         for (int alg = 0; !useFirstInputCompression && alg <= 5; ++alg) {
+            for( int j=0; j<=9; ++j ) {
+               const int comp = (alg*100)+j;
+               snprintf(ft,7,"-f%s%d",prefix,comp);
+               if (!strcmp(argv[a],ft)) {
+                  farg = true;
+                  force = kTRUE;
+                  newcomp = comp;
+                  break;
+               }
+            }
+         }
+         if (!farg) {
+            // Bad argument
+            std::cerr << "Error: option " << argv[a] << " is not a supported option.\n";
+         }
+         ++ffirst;
+      } else if (!outputPlace) {
+         outputPlace = a;
+      }
+   }
+
+   gSystem->Load("libTreePlayer");
+
+   const char *targetname = 0;
+   if (outputPlace) {
+      targetname = argv[outputPlace];
+   } else {
+      targetname = argv[ffirst-1];
+   }
+
+   if (verbosity > 1) {
+      std::cout << "hadd Target file: " << targetname << std::endl;
+   }
+
+   // save all filenames
+   std::vector<std::string> filesToMerge;
+   for (auto i = ffirst; i < argc; i++){
+      if (argv[i]){
+         if (argv[i][0] == '@'){
+            std::ifstream indirect_file(argv[i] + 1);
+            if (!indirect_file.is_open()) {
+               std::cerr << "hadd could not open indirect file " << (argv[i] + 1) << std::endl;
+               break;
+            }
+            std::string line;
+            while (indirect_file) {
+               if (std::getline(indirect_file, line) && line.length()) {
+                  filesToMerge.push_back(line);
+               }
+               else{
+                  break;
+               }
+            }
+         }
+         else {
+            filesToMerge.push_back(argv[i]);
+         }
+      }
+   }
+
+   std::cout << "Files to merge " << filesToMerge.size() << "\n";
+   std::cout << "First: " << filesToMerge[0] << "\n"; 
+   std::cout << "Last: " << filesToMerge[filesToMerge.size()-1] << std::endl;
+   if (filesToMerge.size() < 1){
+      std::cout << "No files to merge!" << std::endl;
+      return 1;
+   }
+
+   TFileMerger fileMerger(kFALSE, kFALSE);
+   fileMerger.SetMsgPrefix("hadd");
+   fileMerger.SetPrintLevel(verbosity - 1);
+   if (maxopenedfiles > 0) {
+      fileMerger.SetMaxOpenedFiles(maxopenedfiles);
+   }
+   if (newcomp == -1) {
+      if (useFirstInputCompression || keepCompressionAsIs) {
+         // grab from the first file.
+         TFile *firstInput = TFile::Open(filesToMerge[0].c_str());
+         if (firstInput && !firstInput->IsZombie())
+            newcomp = firstInput->GetCompressionSettings();
+         else
+            newcomp = ROOT::RCompressionSetting::EDefaults::kUseCompiledDefault % 100;
+         delete firstInput;
+      } else newcomp = ROOT::RCompressionSetting::EDefaults::kUseCompiledDefault % 100; // default compression level.
+   }
+   if (verbosity > 1) {
+      if (keepCompressionAsIs && !reoptimize)
+         std::cout << "hadd compression setting for meta data: " << newcomp << '\n';
+      else
+         std::cout << "hadd compression setting for all output: " << newcomp << '\n';
+   }
+   if (append) {
+      if (!fileMerger.OutputFile(targetname, "UPDATE", newcomp)) {
+         std::cerr << "hadd error opening target file for update :" << argv[ffirst-1] << "." << std::endl;
+         exit(2);
+      }
+   } else if (!fileMerger.OutputFile(targetname, force, newcomp)) {
+      std::cerr << "hadd error opening target file (does " << argv[ffirst-1] << " exist?)." << std::endl;
+      if (!force) std::cerr << "Pass \"-f\" argument to force re-creation of output file." << std::endl;
+      exit(1);
+   }
+
+   auto filesToProcess = filesToMerge.size();
+   auto step = (filesToProcess + nProcesses - 1) / nProcesses;
+   if (multiproc && step < 3) {
+      // At least 3 files per process
+      step = 3;
+      nProcesses = (filesToProcess + step - 1) / step;
+      std::cout << "Each process should handle at least 3 files for efficiency.";
+      std::cout << " Setting the number of processes to: " << nProcesses << std::endl;
+   }
+   if (nProcesses == 1)
+      multiproc = kFALSE;
+
+   std::vector<std::string> partialFiles;
+
+#ifndef R__WIN32
+   // this is commented out only to try to prevent false positive detection
+   // from several anti-virus engines on Windows, and multiproc is not
+   // supported on Windows anyway
+   if (multiproc) {
+      auto uuid = TUUID();
+      auto partialTail = uuid.AsString();
+      for (auto i = 0; (i * step) < filesToProcess; i++) {
+         std::stringstream buffer;
+         buffer << workingDir << "/partial" << i << "_" << partialTail << ".root";
+         partialFiles.emplace_back(buffer.str());
+      }
+   }
+#endif
+
+   auto mergeFiles = [&](TFileMerger &merger) {
+      if (reoptimize) {
+         merger.SetFastMethod(kFALSE);
+      } else {
+         if (!keepCompressionAsIs && merger.HasCompressionChange()) {
+            // Don't warn if the user any request re-optimization.
+            std::cout << "hadd Sources and Target have different compression levels" << std::endl;
+            std::cout << "hadd merging will be slower" << std::endl;
+         }
+      }
+      merger.SetNotrees(noTrees);
+      merger.SetMergeOptions(cacheSize);
+      merger.SetIOFeatures(features);
+      Bool_t status;
+      if (append)
+         status = merger.PartialMerge(TFileMerger::kIncremental | TFileMerger::kAll);
+      else
+         status = merger.Merge();
+      return status;
+   };
+
+   auto sequentialMerge = [&](TFileMerger &merger, int start, int nFiles) {
+
+      // for (auto i = start; i < (start + nFiles) && i < argc; i++) {
+      for (auto i = start; i < (start + nFiles); i++) {
+         if (!merger.AddFile(filesToMerge[i].c_str())) {
+            if (skip_errors) {
+               std::cerr << "hadd skipping file with error: " << filesToMerge[i] << std::endl;
+            } else {
+               std::cerr << "hadd exiting due to error in " << filesToMerge[i] << std::endl;
+               return kFALSE;
+            }
+         }
+      }
+      return mergeFiles(merger);
+   };
+
+   auto parallelMerge = [&](int start) {
+      TFileMerger mergerP(kFALSE, kFALSE);
+      mergerP.SetMsgPrefix("hadd");
+      mergerP.SetPrintLevel(verbosity - 1);
+      if (maxopenedfiles > 0) {
+         mergerP.SetMaxOpenedFiles(maxopenedfiles / nProcesses);
+      }
+      if (!mergerP.OutputFile(partialFiles[(start) / step].c_str(), newcomp)) {
+         std::cerr << "hadd error opening target partial file" << std::endl;
+         exit(1);
+      }
+      return sequentialMerge(mergerP, start, step);
+   };
+
+   auto reductionFunc = [&]() {
+      for (const auto &pf : partialFiles) {
+         fileMerger.AddFile(pf.c_str());
+      }
+      return mergeFiles(fileMerger);
+   };
+
+   Bool_t status;
+
+#ifndef R__WIN32
+   if (multiproc) {
+      ROOT::TProcessExecutor p(nProcesses);
+      auto res = p.Map(parallelMerge, ROOT::TSeqI(0, filesToProcess, step));
+      status = std::accumulate(res.begin(), res.end(), 0U) == partialFiles.size();
+      if (status) {
+         status = reductionFunc();
+      } else {
+         std::cout << "hadd failed at the parallel stage" << std::endl;
+      }
+      if (!debug) {
+         for (const auto &pf : partialFiles) {
+            gSystem->Unlink(pf.c_str());
+         }
+      }
+   } else {
+      status = sequentialMerge(fileMerger, 0, filesToProcess);
+   }
+#else
+   status = sequentialMerge(fileMerger, 0, filesToProcess);
+#endif
+
+   if (status) {
+      if (verbosity == 1) {
+         std::cout << "hadd merged " << fileMerger.GetMergeList()->GetEntries() << " input files in " << targetname
+                   << ".\n";
+      }
+      return 0;
+   } else {
+      if (verbosity == 1) {
+         std::cout << "hadd failure during the merge of " << fileMerger.GetMergeList()->GetEntries()
+                   << " input files in " << targetname << ".\n";
+      }
+      return 1;
+   }
+}


### PR DESCRIPTION
Main changes:
* support for 2D histogram that will be automatically unrolled by `runner.py`. Correct handling of folding (for both bin content and sumw2)
* support for nuisances of type `weight_rm` and `weight_envelope`. Taking the QCDscale as an example for `weight_envelope` varied histograms will be created for each `LHEScaleWeight` specified (so 6 histograms). `mkShapesRDF -o 2`  will `hadd` single histograms and the envelope will be computed right after that, storing only the final envelope up and down
* `hadd2` is included with this PR to support multithreaded hadd when using indirect files. `hadd2 -j 10 @fileList.txt` will correctly work now. `hadd2` is compiled with `install.sh`. The path containing its binary will be added to the $PATH, namely `utils/bin`.
* now nuisances that specify the samples dictionary can have keys that will be `fnmatched` to subsamples keys (e.g. `DY*` will match `DY`, `DY_hardJets` and `DY_PUJets`)
* Including @mlizzo PR